### PR TITLE
Of1906 compatibility

### DIFF
--- a/src/ITHACA_FOMPROBLEMS/UnsteadyNSTurb/UnsteadyNSTurb.C
+++ b/src/ITHACA_FOMPROBLEMS/UnsteadyNSTurb/UnsteadyNSTurb.C
@@ -79,10 +79,10 @@ UnsteadyNSTurb::UnsteadyNSTurb(int argc, char* argv[])
 
 void UnsteadyNSTurb::truthSolve(List<scalar> mu_now)
 {
-#include "initContinuityErrs.H"
     Time& runTime = _runTime();
     surfaceScalarField& phi = _phi();
     fvMesh& mesh = _mesh();
+#include "initContinuityErrs.H"
     fv::options& fvOptions = _fvOptions();
     pimpleControl& pimple = _pimple();
     volScalarField p = _p();

--- a/src/ITHACA_FOMPROBLEMS/unsteadyBB/unsteadyBB.C
+++ b/src/ITHACA_FOMPROBLEMS/unsteadyBB/unsteadyBB.C
@@ -78,7 +78,6 @@ unsteadyBB::unsteadyBB(int argc, char* argv[])
 // Method to performa a truthSolve
 void unsteadyBB::truthSolve(List<scalar> mu_now)
 {
-
     Time& runTime = _runTime();
     fvMesh& mesh = _mesh();
 #include "initContinuityErrs.H"

--- a/src/ITHACA_FOMPROBLEMS/unsteadyBB/unsteadyBB.C
+++ b/src/ITHACA_FOMPROBLEMS/unsteadyBB/unsteadyBB.C
@@ -78,9 +78,10 @@ unsteadyBB::unsteadyBB(int argc, char* argv[])
 // Method to performa a truthSolve
 void unsteadyBB::truthSolve(List<scalar> mu_now)
 {
-#include "initContinuityErrs.H"
+
     Time& runTime = _runTime();
     fvMesh& mesh = _mesh();
+#include "initContinuityErrs.H"
     volScalarField& p = _p();
     volVectorField& U = _U();
     volScalarField& p_rgh = _p_rgh();

--- a/src/ITHACA_FOMPROBLEMS/unsteadyNS/unsteadyNS.C
+++ b/src/ITHACA_FOMPROBLEMS/unsteadyNS/unsteadyNS.C
@@ -73,10 +73,10 @@ unsteadyNS::unsteadyNS(int argc, char* argv[])
 
 void unsteadyNS::truthSolve(List<scalar> mu_now)
 {
-#include "initContinuityErrs.H"
     Time& runTime = _runTime();
     surfaceScalarField& phi = _phi();
     fvMesh& mesh = _mesh();
+#include "initContinuityErrs.H"
     fv::options& fvOptions = _fvOptions();
     pimpleControl& pimple = _pimple();
     volScalarField& p = _p();

--- a/src/ITHACA_FOMPROBLEMS/unsteadyNST/unsteadyNST.C
+++ b/src/ITHACA_FOMPROBLEMS/unsteadyNST/unsteadyNST.C
@@ -75,10 +75,10 @@ unsteadyNST::unsteadyNST(int argc, char* argv[])
 void unsteadyNST::truthSolve(List<scalar> mu_now)
 
 {
-#include "initContinuityErrs.H"
     Time& runTime = _runTime();
     surfaceScalarField& phi = _phi();
     fvMesh& mesh = _mesh();
+#include "initContinuityErrs.H"
     pisoControl& piso = _piso();
     volScalarField& p = _p();
     volVectorField& U = _U();

--- a/src/ITHACA_FOMPROBLEMS/unsteadyNSTturb/unsteadyNSTturb.C
+++ b/src/ITHACA_FOMPROBLEMS/unsteadyNSTturb/unsteadyNSTturb.C
@@ -66,10 +66,10 @@ unsteadyNSTturb::unsteadyNSTturb(int argc, char* argv[])
 
 void unsteadyNSTturb::truthSolve(List<scalar> mu_now)
 {
-#include "initContinuityErrs.H"
     Time& runTime = _runTime();
     surfaceScalarField& phi = _phi();
     fvMesh& mesh = _mesh();
+#include "initContinuityErrs.H"
     fv::options& fvOptions = _fvOptions();
     pisoControl& piso = _piso();
     volScalarField p = _p();


### PR DESCRIPTION
This branch is a modification of the code to be able to use the ITHACA-FV libs in OF1906.
The main problem to date is that the changes in the function InitContinuityErrs.H of v1906 requires the mesh and runtime to be created first.
The unsteady solvers have been modified in order to be able to compile the libreary using Allwmake.