### PR TITLE
Add method to compute the combined time-parameter matrix

### DIFF
--- a/src/ITHACA_CORE/ITHACAutilities/ITHACAutilities.C
+++ b/src/ITHACA_CORE/ITHACAutilities/ITHACAutilities.C
@@ -969,6 +969,37 @@ void ITHACAutilities::assignBC(volVectorField& s, label BC_ind,
     }
 }
 
+Eigen::MatrixXd ITHACAutilities::parTimeCombMat(List<Eigen::VectorXd>
+        acquiredSnapshotsTimes,
+        Eigen::MatrixXd parameters)
+{
+    int parsNum = parameters.cols();
+    int parsSamplesNum = parameters.rows();
+    M_Assert(parsSamplesNum == acquiredSnapshotsTimes.size(),
+             "The list of time instants does not have the same number of vectors as the number of parameters samples");
+    Eigen::MatrixXd comb;
+    int totalSnapshotsNum = 0;
+
+    for (label k = 0; k < acquiredSnapshotsTimes.size(); k++)
+    {
+        totalSnapshotsNum += acquiredSnapshotsTimes[k].size();
+    }
+
+    comb.resize(totalSnapshotsNum, parsNum + 1);
+    label i = 0;
+
+    for (label j = 0; j < acquiredSnapshotsTimes.size(); j++)
+    {
+        for (label k = 0; k < acquiredSnapshotsTimes[j].size(); k++)
+        {
+            comb(i, parsNum) = (acquiredSnapshotsTimes[j])(k, 0);
+            comb.block(i, 0, 1, parsNum) = parameters.row(j);
+            i = i + 1;
+        }
+    }
+
+    return comb;
+}
 
 template<class TypeField>
 void ITHACAutilities::changeBCtype(

--- a/src/ITHACA_CORE/ITHACAutilities/ITHACAutilities.H
+++ b/src/ITHACA_CORE/ITHACAutilities/ITHACAutilities.H
@@ -462,6 +462,21 @@ class ITHACAutilities
         static void assignBC(volScalarField& s, label BC_ind, Eigen::MatrixXd valueVec);
 
         //--------------------------------------------------------------------------
+        /// @brief      A method to comput the time-parameter combined matrix whose any single element
+        /// corresponds to a unique snapshot in the snapshots acquired for the offline stage
+        ///
+        /// @param[in]  acquiredSnapshotsTimes  The time instants at which snapshots are acquired
+        /// @param[in]  parameters   The parameters for which the simulations are run oredered with respect to
+        /// vectors acquiredSnapshotsTimes which contain the corresponding time instants at which we acquired
+        /// snapshots
+        ///
+        /// @return     A matrix which has in each row the parameters value and the time instants which
+        /// correspond to a unique snapshot in the offline folder.
+        ///
+        static Eigen::MatrixXd parTimeCombMat(List<Eigen::VectorXd>
+                                              acquiredSnapshotsTimes, Eigen::MatrixXd parameters);
+
+        //--------------------------------------------------------------------------
         /// Evaluate the L2 norm of a volScalarField
         ///
         /// @param[in]  field  The field.


### PR DESCRIPTION
Add method to compute the combined time-parameter matrix for the case of unsteady parametrized problems, each row must correspond to one unique snapshot in the offline folder. Rows are arranged in order with respect to the order of snapshots in the offline folder.