### PR TITLE
Rewrite the way the RBF interpolation is done both offline and online

### DIFF
--- a/src/ITHACA_CORE/ITHACAutilities/ITHACAutilities.C
+++ b/src/ITHACA_CORE/ITHACAutilities/ITHACAutilities.C
@@ -1007,6 +1007,41 @@ void ITHACAutilities::assignBC(volVectorField& s, label BC_ind,
         }
     }
 }
+template<class TypeField>
+PtrList<TypeField> ITHACAutilities::averageSubtract(PtrList<TypeField>
+        fields, Eigen::MatrixXd ind, PtrList<TypeField>& ave)
+{
+    PtrList<TypeField> aveSubtracted;
+    Eigen::VectorXd newInd;
+    newInd.resize(ind.size() + 1);
+    newInd.head(ind.size()) = ind;
+    newInd(ind.size()) = fields.size();
+
+    for (label i = 0; i < ind.size(); i++)
+    {
+        TypeField aveTemp("nut", fields[0] * 0);
+
+        for (label j = newInd(i); j < newInd(i + 1); j++)
+        {
+            aveTemp += fields[j];
+        }
+
+        aveTemp /= newInd(i + 1) - newInd(i);
+        ave.append(aveTemp);
+    }
+
+    for (label i = 0; i < ind.size(); i++)
+    {
+        for (label j = newInd(i); j < newInd(i + 1); j++)
+        {
+            TypeField newfield("nut", fields[0] * 0);
+            newfield = fields[j] - ave[i];
+            aveSubtracted.append(newfield);
+        }
+    }
+
+    return aveSubtracted;
+}
 
 Eigen::MatrixXd ITHACAutilities::parTimeCombMat(List<Eigen::VectorXd>
         acquiredSnapshotsTimes,
@@ -1457,6 +1492,13 @@ template PtrList<volScalarField> ITHACAutilities::reconstruct_from_coeff(
     PtrList<volScalarField>& modes, Eigen::MatrixXd& coeff_matrix, label Nmodes);
 template PtrList<volVectorField> ITHACAutilities::reconstruct_from_coeff(
     PtrList<volVectorField>& modes, Eigen::MatrixXd& coeff_matrix, label Nmodes);
+
+template PtrList<volScalarField> ITHACAutilities::averageSubtract(
+    PtrList<volScalarField>
+    fields, Eigen::MatrixXd ind, PtrList<volScalarField>& ave);
+template PtrList<volVectorField> ITHACAutilities::averageSubtract(
+    PtrList<volVectorField>
+    fields, Eigen::MatrixXd ind, PtrList<volVectorField>& ave);
 
 template double ITHACAutilities::error_fields(volScalarField& field1,
         volScalarField& field2);

--- a/src/ITHACA_CORE/ITHACAutilities/ITHACAutilities.H
+++ b/src/ITHACA_CORE/ITHACAutilities/ITHACAutilities.H
@@ -277,6 +277,23 @@ class ITHACAutilities
         static Eigen::MatrixXd error_listfields_abs(PtrList<TypeField>& fields1,
                 PtrList<TypeField>& fields2);
 
+        //-----------------------------------------------------------------------------
+        /// @brief      A function to compute time-averaged fields for a set of different parameter samples
+        /// and also the fields with the corresponding averaged subtracted
+        ///
+        /// @param[in]  fields     The fields from which the time-averaged fields have to be computed
+        /// @param[in]  ind        The indices at which fields for different samples of the parameter start
+        /// @param      ave        The computed time-averaged fields
+        ///
+        /// @tparam     TypeField  Type of field
+        ///
+        /// @return     A list of fields which correspond to the original fields subtracted by
+        /// the time-averaged part
+        ///
+        template<class TypeField>
+        static PtrList<TypeField> averageSubtract(PtrList<TypeField>
+                fields, Eigen::MatrixXd ind, PtrList<TypeField>& ave);
+
         //--------------------------------------------------------------------------
         /// Computes a Mass Matrix from a list of Basis Functions (vectorial) for L2 projection
         ///

--- a/src/ITHACA_FOMPROBLEMS/UnsteadyNSTurb/UnsteadyNSTurb.H
+++ b/src/ITHACA_FOMPROBLEMS/UnsteadyNSTurb/UnsteadyNSTurb.H
@@ -82,6 +82,9 @@ class UnsteadyNSTurb: public unsteadyNS
         /// List of POD modes for eddy viscosity
         PtrList<volScalarField> nutModes;
 
+        /// List of for eddy viscosity time-averaged fields
+        PtrList<volScalarField> nutAve;
+
         /// Create a Rbf splines for interpolation
         std::vector<SPLINTER::DataTable*> samples;
 
@@ -91,17 +94,44 @@ class UnsteadyNSTurb: public unsteadyNS
         /// Turbulent viscosity term
         Eigen::MatrixXd btMatrix;
 
-        /// Turbulent viscosity tensor
-        List <Eigen::MatrixXd> ct2Matrix;
-        Eigen::Tensor<double, 3 > ct2Tensor;
+        /// Time-parameter combined matrix
+        Eigen::MatrixXd z;
 
         /// Turbulent viscosity tensor
-        List <Eigen::MatrixXd> ct1Matrix;
         Eigen::Tensor<double, 3 > ct1Tensor;
 
-        /// Total Turbulent tensor
-        List <Eigen::MatrixXd> cTotalMatrix;
+        /// Turbulent average viscosity tensor for the splitting approach
+        Eigen::Tensor<double, 3 > ct1AveTensor;
+
+        /// Turbulent viscosity tensor in the PPE equation
+        Eigen::Tensor<double, 3 > ct1PPETensor;
+
+        /// Turbulent average viscosity tensor for the splitting approach in the PPE equation
+        Eigen::Tensor<double, 3 > ct1PPEAveTensor;
+
+        /// Turbulent viscosity tensor
+        Eigen::Tensor<double, 3 > ct2Tensor;
+
+        /// Turbulent average viscosity tensor for the splitting approach
+        Eigen::Tensor<double, 3 > ct2AveTensor;
+
+        /// Turbulent viscosity tensor in the PPE equation
+        Eigen::Tensor<double, 3 > ct2PPETensor;
+
+        /// Turbulent average viscosity tensor for the splitting approach in the PPE equation
+        Eigen::Tensor<double, 3 > ct2PPEAveTensor;
+
+        /// Turbulent total viscosity tensor
         Eigen::Tensor<double, 3 > cTotalTensor;
+
+        /// Turbulent total average viscosity tensor for the splitting approach
+        Eigen::Tensor<double, 3 > cTotalAveTensor;
+
+        /// Turbulent total viscosity tensor in the PPE equation
+        Eigen::Tensor<double, 3 > cTotalPPETensor;
+
+        /// Turbulent total average viscosity tensor for the splitting approach in the PPE equation
+        Eigen::Tensor<double, 3 > cTotalPPEAveTensor;
 
         /// Total B Matrix
         Eigen::MatrixXd bTotalMatrix;
@@ -109,11 +139,17 @@ class UnsteadyNSTurb: public unsteadyNS
         /// The matrix of L2 projection coefficients for the eddy viscosity
         Eigen::MatrixXd coeffL2;
 
-        /// The vector of L2 projection coefficients for the eddy viscosity snapshot
-        Eigen::VectorXd nutCoeff;
+        /// Velocity coefficients for RBF interpolation
+        Eigen::MatrixXd velRBF;
+
+        /// RBF functions radius
+        double e = 1;
 
         /// Number of viscoisty modes used for the projection
         label nNutModes;
+
+        /// Interpolation independent variable choice
+        int interChoice = 1;
 
         /// Eddy viscosity field
         autoPtr<volScalarField> _nut;
@@ -129,19 +165,7 @@ class UnsteadyNSTurb: public unsteadyNS
         Eigen::MatrixXd btTurbulence(label NUmodes, label NSUPmodes);
 
         //--------------------------------------------------------------------------
-        /// @brief      ct1 added matrix for the turbulence treatement
-        ///
-        /// @param[in]  NUmodes    The number of velocity modes.
-        /// @param[in]  NSUPmodes  The number of supremizer modes.
-        /// @param[in]  nNutModes  The number of eddy viscosity modes.
-        ///
-        /// @return     ct1 matrix for turbulence treatment
-        ///
-        List < Eigen::MatrixXd > turbulenceTerm1(label NUmodes, label NSUPmodes,
-                label nNutModes);
-
-        //--------------------------------------------------------------------------
-        /// @brief      { function_description }
+        /// @brief      ct1 added tensor for the turbulence treatement
         ///
         /// @param[in]  NUmodes    The number of velocity modes.
         /// @param[in]  NSUPmodes  The number of supremizer modes.
@@ -153,19 +177,7 @@ class UnsteadyNSTurb: public unsteadyNS
                 label NSUPmodes, label nNutModes);
 
         //--------------------------------------------------------------------------
-        /// @brief      ct2 added matrix for the turbulence treatement
-        ///
-        /// @param[in]  NUmodes    The number of velocity modes.
-        /// @param[in]  NSUPmodes  The number of supremizer modes.
-        /// @param[in]  nNutModes  The number of eddy viscosity modes.
-        ///
-        /// @return     ct2 matrix for turbulence treatment
-        ///
-        List < Eigen::MatrixXd > turbulenceTerm2(label NUmodes, label NSUPmodes,
-                label nNutModes);
-
-        //--------------------------------------------------------------------------
-        /// @brief      { function_description }
+        /// @brief      ct2 added tensor for the turbulence treatement
         ///
         /// @param[in]  NUmodes    The number of velocity modes.
         /// @param[in]  NSUPmodes  The number of supremizer modes.
@@ -176,6 +188,81 @@ class UnsteadyNSTurb: public unsteadyNS
         Eigen::Tensor<double, 3 > turbulenceTensor2(label NUmodes,
                 label NSUPmodes, label nNutModes);
 
+        //--------------------------------------------------------------------------
+        /// @brief      ct1PPE added tensor for the turbulence treatement in the PPE method
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        /// @param[in]  NPmodes    The number of pressure modes.
+        /// @param[in]  nNutModes  The number of eddy viscosity modes.
+        ///
+        /// @return     ct1PPE tensor for the turbulence treatement in the PPE method
+        ///
+        Eigen::Tensor<double, 3 > turbulencePPETensor1(label NUmodes,
+                label NSUPmodes, label NPmodes, label nNutModes);
+
+        //--------------------------------------------------------------------------
+        /// @brief      ct2PPE added tensor for the turbulence treatement in the PPE method
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        /// @param[in]  NPmodes    The number of pressure modes.
+        /// @param[in]  nNutModes  The number of eddy viscosity modes.
+        ///
+        /// @return     ct2PPE tensor for the turbulence treatement in the PPE method
+        ///
+        Eigen::Tensor<double, 3 > turbulencePPETensor2(label NUmodes,
+                label NSUPmodes, label NPmodes, label nNutModes);
+
+        //--------------------------------------------------------------------------
+        /// @brief      ct1Ave added tensor for approximation of the averaged part of the eddy viscosity
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        ///
+        /// @return     ct1Ave tensor corresponding to the approximation of the averaged part
+        ///  of the eddy viscosity for the turbulence treatement
+        ///
+        Eigen::Tensor<double, 3> turbulenceAveTensor1(label NUmodes,
+                label NSUPmodes);
+
+        //--------------------------------------------------------------------------
+        /// @brief      ct2Ave added tensor for approximation of the averaged part of the eddy viscosity
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        ///
+        /// @return     ct2Ave tensor corresponding to the approximation of the averaged part
+        ///  of the eddy viscosity for the turbulence treatement
+        ///
+        Eigen::Tensor<double, 3> turbulenceAveTensor2(label NUmodes,
+                label NSUPmodes);
+        //--------------------------------------------------------------------------
+        /// @brief      ct1PPEAve added tensor for approximation of the averaged part of the eddy viscosity
+        /// with the usage of the PPE approach
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        /// @param[in]  NPmodes    The number of pressure modes.
+        ///
+        /// @return     ct1PPEAve tensor corresponding to the approximation of the averaged part
+        ///  of the eddy viscosity for the turbulence treatement with the usage of the PPE approach
+        ///
+        Eigen::Tensor<double, 3> turbulencePPEAveTensor1(label NUmodes,
+                label NSUPmodes, label NPmodes);
+        //--------------------------------------------------------------------------
+        /// @brief      ct2PPEAve added tensor for approximation of the averaged part of the eddy viscosity
+        /// with the usage of the PPE approach
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        /// @param[in]  NPmodes    The number of pressure modes.
+        ///
+        /// @return     ct2PPEAve tensor corresponding to the approximation of the averaged part
+        ///  of the eddy viscosity for the turbulence treatement with the usage of the PPE approach
+        ///
+        Eigen::Tensor<double, 3> turbulencePPEAveTensor2(label NUmodes,
+                label NSUPmodes, label NPmodes);
         //--------------------------------------------------------------------------
         /// @brief      Perform a truthsolve
         /// @param[in]  mu_now  The actual value of the parameter for this truthSolve. Used only
@@ -207,6 +294,70 @@ class UnsteadyNSTurb: public unsteadyNS
         ///
         void projectPPE(fileName folder, label NUmodes, label NPmodes, label NSUPmodes,
                         label nNutModes);
+
+        //--------------------------------------------------------------------------
+        /// @brief      A method to compute the two matrices needed for the RBF interpolation by combining
+        /// the velocity L2 projection coefficients and their time derivatives
+        ///
+        /// @param[in]  A            The velocity L2 projection coefficients
+        /// @param[in]  G            The eddy viscoisty L2 projection coefficients
+        /// @param[in]  initSnapInd  The initial snapshots indices for the different parameter samples
+        /// @param[in]  timeSnap     The time rate at which snapshots were taken for the different parameter samples
+        ///
+        /// @return     The matrix of the combined velocity L2 projection coefficients starting from the second
+        /// snapshots for each parameter sample together with their time derivatives and also the matrix of the
+        /// eddy viscosity L2 projection coefficients associated with the first matrix
+        ///
+        List < Eigen::MatrixXd > velDerivativeCoeff(Eigen::MatrixXd A,
+                Eigen::MatrixXd G,
+                Eigen::VectorXd initSnapInd, Eigen::VectorXd timeSnap);
+
+        //--------------------------------------------------------------------------
+        /// @brief      A method to compute the two matrices needed for the RBF interpolation by combining
+        /// the parameter samples values with the velocity L2 projection coefficients
+        ///
+        /// @param[in]  A            The velocity L2 projection coefficients
+        /// @param[in]  G            The eddy viscoisty L2 projection coefficients
+        ///
+        /// @return     The matrix of the combined parameter and velocity L2 projection coefficients and also
+        /// the corresponding matrix of eddy viscosity L2 projection coefficients
+        ///
+        List < Eigen::MatrixXd > velParCoeff(Eigen::MatrixXd A, Eigen::MatrixXd G);
+
+
+        //--------------------------------------------------------------------------
+        /// @brief      A method to compute the two matrices needed for the RBF interpolation by combining
+        /// the parameter value and the velocity L2 projection coefficients and their time derivatives
+        ///
+        /// @param[in]  A            The velocity L2 projection coefficients
+        /// @param[in]  G            The eddy viscoisty L2 projection coefficients
+        /// @param[in]  initSnapInd  The initial snapshots indices for the different parameter samples
+        /// @param[in]  timeSnap     The time rate at which snapshots were taken for the different parameter samples
+        ///
+        /// @return     The matrix of the combined parameter samples values with their corresponding
+        /// velocity L2 projection coefficients starting from the second snapshots for each
+        /// parameter sample together with their time derivatives and also the matrix of the
+        /// eddy viscosity L2 projection coefficients associated with the previous matrix
+        ///
+        List < Eigen::MatrixXd > velParDerivativeCoeff(Eigen::MatrixXd A,
+                Eigen::MatrixXd G,
+                Eigen::VectorXd initSnapInd, Eigen::VectorXd timeSnap);
+
+        //--------------------------------------------------------------------------
+        /// @brief      A method to compute the matrix of the combination of the parameter sample value and
+        /// the matrix of velocity projection coefficients together with their time derivatives
+        /// based on the backward scheme
+        ///
+        /// @param[in]  A         The velocity L2 projection coefficients
+        /// @param[in]  par       The parameter vector corresponding to the matrix A
+        /// @param[in]  timeSnap  The time rate at which snapshots are taken in matrix A
+        ///
+        /// @return     the matrix of the combination of the parameter sample value and
+        /// the matrix of velocity projection coefficients together with their time derivatives
+        /// based on the backward scheme
+        ///
+        Eigen::MatrixXd velParDerivativeCoeff(Eigen::MatrixXd A,
+                                              Eigen::VectorXd par, double timeSnap);
 
 };
 

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurb/ReducedUnsteadyNSTurb.H
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurb/ReducedUnsteadyNSTurb.H
@@ -113,6 +113,75 @@ struct newtonUnsteadyNSTurbPPE: public newton_argument<double>
         std::vector<SPLINTER::RBFSpline*> SPLINES;
 };
 
+struct newtonUnsteadyNSTurbSUPAve: public newton_argument<double>
+{
+    public:
+        newtonUnsteadyNSTurbSUPAve() {}
+        newtonUnsteadyNSTurbSUPAve(int Nx, int Ny,
+                                   UnsteadyNSTurb& problem): newton_argument<double>(Nx, Ny),
+            problem(&problem),
+            Nphi_u(problem.NUmodes + problem.liftfield.size() + problem.NSUPmodes),
+            nphiNut(problem.nNutModes),
+            Nphi_p(problem.NPmodes),
+            N_BC(problem.inletIndex.rows()),
+            gNut(problem.nNutModes),
+            gNutAve(problem.nutAve.size())
+        {}
+
+        int operator()(const Eigen::VectorXd& x, Eigen::VectorXd& fvec) const;
+        int df(const Eigen::VectorXd& x,  Eigen::MatrixXd& fjac) const;
+
+        UnsteadyNSTurb* problem;
+        int Nphi_u;
+        int nphiNut;
+        int Nphi_p;
+        int N_BC;
+        scalar nu;
+        scalar dt;
+        Eigen::VectorXd y_old;
+        Eigen::VectorXd yOldOld;
+        Eigen::VectorXd bc;
+        Eigen::MatrixXd tauU;
+        Eigen::VectorXd gNut;
+        Eigen::VectorXd gNutAve;
+        std::vector<SPLINTER::RBFSpline*> SPLINES;
+};
+
+struct newtonUnsteadyNSTurbPPEAve: public newton_argument<double>
+{
+    public:
+        newtonUnsteadyNSTurbPPEAve() {}
+        newtonUnsteadyNSTurbPPEAve(int Nx, int Ny,
+                                   UnsteadyNSTurb& problem): newton_argument<double>(Nx, Ny),
+            problem(&problem),
+            Nphi_u(problem.NUmodes + problem.liftfield.size()),
+            nphiNut(problem.nNutModes),
+            Nphi_p(problem.NPmodes),
+            N_BC(problem.inletIndex.rows()),
+            gNut(problem.nNutModes),
+            gNutAve(problem.nutAve.size())
+
+        {}
+
+        int operator()(const Eigen::VectorXd& x, Eigen::VectorXd& fvec) const;
+        int df(const Eigen::VectorXd& x,  Eigen::MatrixXd& fjac) const;
+
+        UnsteadyNSTurb* problem;
+        int Nphi_u;
+        int nphiNut;
+        int Nphi_p;
+        int N_BC;
+        scalar nu;
+        scalar dt;
+        Eigen::VectorXd y_old;
+        Eigen::VectorXd yOldOld;
+        Eigen::VectorXd bc;
+        Eigen::MatrixXd tauU;
+        Eigen::VectorXd gNut;
+        Eigen::VectorXd gNutAve;
+        std::vector<SPLINTER::RBFSpline*> SPLINES;
+};
+
 
 
 /*---------------------------------------------------------------------------*\
@@ -144,40 +213,77 @@ class ReducedUnsteadyNSTurb: public reducedUnsteadyNS
         /// Number of viscosity modes
         int nphiNut;
 
+        /// Dimension of the interpolation independent variable
+        int dimA;
+
         /// List of pointers to store the modes for the eddy viscosity
         PtrList<volScalarField> nutModes;
 
         /// The matrix of the eddy viscosity RBF interoplated coefficients
         Eigen::MatrixXd rbfCoeffMat;
 
+        /// The matrix of the initial velocity and pressure reduced coefficients
+        Eigen::MatrixXd initCond;
+
+        /// The initial eddy viscosity reduced coefficients
+        Eigen::VectorXd nut0;
+
         /// Function object to call the non linear solver sup approach
         newtonUnsteadyNSTurbSUP newtonObjectSUP;
+
+        /// Function object to call the non linear solver sup approach with the splitting of the eddy viscosity
+        newtonUnsteadyNSTurbSUPAve newtonObjectSUPAve;
 
         /// Function object to call the non linear solver PPE approach
         newtonUnsteadyNSTurbPPE newtonObjectPPE;
 
+        /// Function object to call the non linear solver PPE approach with the splitting of the eddy viscosity
+        newtonUnsteadyNSTurbPPEAve newtonObjectPPEAve;
+
+        /// Online parameter value
+        Eigen::VectorXd muStar;
+
+        /// The reduced average vector for viscosity coefficients
+        Eigen::VectorXd gNutAve;
+
+        /// Interpolation independent variable choice
+        int interChoice = 1;
+
         // Functions
 
-
+        ///
         /// Method to perform an online solve using a PPE stabilisation method
         ///
         /// @param[in]  velNow   The vector of online velocity. It is defined in
         /// with an Eigen::MatrixXd and must have one col and as many rows as the number
         /// of parametrized boundary conditions.
-        /// @param[in]  startSnap The first snapshot taken from the offline snahpshots
-        /// and used to get the reduced initial condition.
         ///
-        void solveOnlinePPE(Eigen::MatrixXd velNow, label startSnap = 0);
+        void solveOnlinePPE(Eigen::MatrixXd velNow);
 
+        ///
         /// Method to perform an online solve using a supremizer stabilisation method
         ///
         /// @param[in]  velNow   The vector of online velocity. It is defined in
         /// with an Eigen::MatrixXd and must have one col and as many rows as the number
         /// of parametrized boundary conditions.
-        /// @param[in]  startSnap The first snapshot taken from the offline snahpshots
-        /// and used to get the reduced initial condition.
         ///
-        void solveOnlineSUP(Eigen::MatrixXd velNow, label startSnap = 0);
+        void solveOnlineSUP(Eigen::MatrixXd velNow);
+
+        ///
+        /// Method to perform an online solve using a supremizer stabilisation method
+        /// with the use of the average splitting approach for the eddy viscosity
+        ///
+        /// @param[in]  velNow  The velocity now
+        ///
+        void solveOnlineSUPAve(Eigen::MatrixXd velNow);
+
+        ///
+        /// Method to perform an online solve using a PPE stabilisation method
+        /// with the use of the average splitting approach for the eddy viscosity
+        ///
+        /// @param[in]  velNow  The velocity now
+        ///
+        void solveOnlinePPEAve(Eigen::MatrixXd velNow);
 
         /// Method to reconstruct a solution from an online solve with a PPE stabilisation technique.
         /// stabilisation method


### PR DESCRIPTION
Adding the methods needed to construct the interpolation matrices in UnsteadyNSTurb, adding new members in UnsteadyNSTurb and ReducedUnsteadyNSTurb, adding the methods for the splitting approach for the eddy viscosity in both offline and online classes, making interpolation in the online class automatic based on the dimension of the interpolation independent variable.
