### PR TITLE
ENH/FIX: The intrusive turbulent class PPE method has been added for both the FOM and the ROM classes.

### DIFF
--- a/src/ITHACA_FOMPROBLEMS/UnsteadyNSTurbIntrusive/UnsteadyNSTurbIntrusive.H
+++ b/src/ITHACA_FOMPROBLEMS/UnsteadyNSTurbIntrusive/UnsteadyNSTurbIntrusive.H
@@ -100,8 +100,17 @@ class UnsteadyNSTurbIntrusive: public unsteadyNS
         /// Turbulent viscosity tensor
         Eigen::Tensor<double, 3 > ct1Tensor;
 
+        /// Turbulent viscosity tensor PPE approach
+        Eigen::Tensor<double, 3 > ct1PPETensor;
+
+        /// Turbulent viscosity tensor PPE approach
+        Eigen::Tensor<double, 3 > ct2PPETensor;
+
         /// Total Turbulent tensor
         Eigen::Tensor<double, 3 > cTotalTensor;
+
+        /// Total Turbulent tensor PPE approach
+        Eigen::Tensor<double, 3 > cTotalPPETensor;
 
         /// Total B Matrix
         Eigen::MatrixXd bTotalMatrix;
@@ -157,7 +166,6 @@ class UnsteadyNSTurbIntrusive: public unsteadyNS
         ///
         Eigen::Tensor<double, 3 > turbulenceTensor1(label nModes);
 
-
         //--------------------------------------------------------------------------
         /// @brief      Method to compute one of the turbulence tensors
         ///
@@ -166,6 +174,26 @@ class UnsteadyNSTurbIntrusive: public unsteadyNS
         /// @return     ct2 tensor for the turbulence treatement
         ///
         Eigen::Tensor<double, 3 > turbulenceTensor2(label nModes);
+
+        //--------------------------------------------------------------------------
+        /// @brief      Method to compute one of the turbulence eddy viscosity tensors in the PPE approach
+        ///
+        /// @param[in]  nUModes  The number of modes used in the online stage for the velocity and eddy viscosity fields
+        /// @param[in]  nPModes  The number of modes used in the online stage for the pressure field
+        ///
+        /// @return     ct1PPE tensor for the turbulence treatement in the PPE approach
+        ///
+        Eigen::Tensor<double, 3 > turbulencePPETensor1(label nUModes, label nPModes);
+
+        //--------------------------------------------------------------------------
+        /// @brief      Method to compute one of the turbulence eddy viscosity tensors in the PPE approach
+        ///
+        /// @param[in]  nUModes  The number of modes used in the online stage for the velocity and eddy viscosity fields
+        /// @param[in]  nPModes  The number of modes used in the online stage for the pressure field
+        ///
+        /// @return     ct2PPE tensor for the turbulence treatement in the PPE approach
+        ///
+        Eigen::Tensor<double, 3 > turbulencePPETensor2(label nUModes, label nPModes);
 
         //--------------------------------------------------------------------------
         /// @brief      Diffusive Term

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurbIntrusive/ReducedUnsteadyNSTurbIntrusive.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurbIntrusive/ReducedUnsteadyNSTurbIntrusive.C
@@ -179,6 +179,7 @@ int newtonUnsteadyNSTurbIntrusivePPE::operator()(const Eigen::VectorXd& x,
     Eigen::MatrixXd cc(1, 1);
     Eigen::MatrixXd gg(1, 1);
     Eigen::MatrixXd bb(1, 1);
+    Eigen::MatrixXd nn(1, 1);
     // Mom Term
     Eigen::VectorXd m1 = problem->bTotalMatrix * aTmp * nu;
     // Gradient of pressure
@@ -221,8 +222,9 @@ int newtonUnsteadyNSTurbIntrusivePPE::operator()(const Eigen::VectorXd& x,
                 j) * aTmp;
         bb = aTmp.transpose() * Eigen::SliceFromTensor(problem->bc2Tensor, 0,
                 j) * aTmp;
-        //fvec(k) = m3(j, 0) - gg(0, 0) - m6(j, 0) + bb(0, 0);
-        fvec(k) = m3(j, 0) + gg(0, 0) - m7(j, 0);
+        nn = aTmp.transpose() * Eigen::SliceFromTensor(problem->cTotalPPETensor, 0,
+                j) * aTmp;
+        fvec(k) = m3(j, 0) + gg(0, 0) - m7(j, 0) - nn(0, 0);
     }
 
     if (problem->bcMethod == "lift")


### PR DESCRIPTION
The intrusive turbulent class PPE method has been added for both the FOM and the ROM classes. The method to compute the turbulent PPE tensors were lacking. At the reduced order level, the assembly of the corresponding tensor has been added.