### PR TITLE
Update the reconstruct method for the unsteady turbulent hybrid class

### DIFF
--- a/src/ITHACA_FOMPROBLEMS/SteadyNSSimple/SteadyNSSimple.C
+++ b/src/ITHACA_FOMPROBLEMS/SteadyNSSimple/SteadyNSSimple.C
@@ -306,14 +306,16 @@ void SteadyNSSimple::truthSolve2(List<scalar> mu_now, word Folder)
             ITHACAstream::exportSolution(p, name(folderN), Folder + name(counter));
             Ufield.append(U);
             Pfield.append(p);
+
             if (ITHACAutilities::isTurbulent())
-                {
-                    auto nut = mesh.lookupObject<volScalarField>("nut");
-                    ITHACAstream::exportSolution(nut, name(folderN), Folder + name(counter));
-                    nutFields.append(nut);
-                }
+            {
+                auto nut = mesh.lookupObject<volScalarField>("nut");
+                ITHACAstream::exportSolution(nut, name(folderN), Folder + name(counter));
+                nutFields.append(nut);
+            }
         }
     }
+
     res_os << residual << std::endl;
     res_os.close();
     runTime.setTime(runTime.startTime(), 0);

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurb/ReducedUnsteadyNSTurb.H
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurb/ReducedUnsteadyNSTurb.H
@@ -249,6 +249,9 @@ class ReducedUnsteadyNSTurb: public reducedUnsteadyNS
         /// Interpolation independent variable choice
         int interChoice = 1;
 
+        /// Reconstructed eddy viscosity fields list
+        PtrList<volScalarField> nutRecFields;
+
         // Functions
 
         ///
@@ -285,19 +288,14 @@ class ReducedUnsteadyNSTurb: public reducedUnsteadyNS
         ///
         void solveOnlinePPEAve(Eigen::MatrixXd velNow);
 
-        /// Method to reconstruct a solution from an online solve with a PPE stabilisation technique.
-        /// stabilisation method
+        /// Method to reconstruct the solutions from an online solve with any of
+        /// the two techniques SUP or the PPE
         ///
-        /// @param[in]  folder      The folder where to output the solutions
+        /// @param[in]  exportFields  A boolean variable which determines whether to export fields or not
+        /// @param[in]  folder        The folder where to output the solutions in case on wants to
         ///
-        void reconstructPPE(fileName folder = "./online_rec");
-
-        /// Method to reconstruct the solutions from an online solve with a supremizer stabilisation technique.
-        /// stabilisation method
-        ///
-        /// @param[in]  folder      The folder where to output the solutions
-        ///
-        void reconstructSUP(fileName folder = "./online_rec");
+        void reconstruct(bool exportFields = false,
+                         fileName folder = "./online_rec");
 
         ///
         /// @brief      Sets the online velocity.


### PR DESCRIPTION
Update the reconstruct method for the unsteady turbulent hybrid class, now may choose to export the solution fields by triggering a boolean variable in the reconstruct method which is general for both the SUP and the PPE formulations.