### PR TITLE
FIX: forced the runTime into the restart() function in steadyNS.C to …

### DIFF
--- a/src/ITHACA_FOMPROBLEMS/steadyNS/steadyNS.C
+++ b/src/ITHACA_FOMPROBLEMS/steadyNS/steadyNS.C
@@ -1451,6 +1451,7 @@ void steadyNS::restart()
     _fvOptions.clear();
     argList& args = _args();
     Time& runTime = _runTime();
+    runTime.setTime(0, 1);
     Foam::fvMesh& mesh = _mesh();
     _simple = autoPtr<simpleControl>
               (


### PR DESCRIPTION
…be equal zero