### PR TITLE
TEST: Include compilation tests on ITHACA dependences.

### DIFF
--- a/.compileOF1812.sh
+++ b/.compileOF1812.sh
@@ -1,4 +1,5 @@
-docker pull openfoamplus/of_v1812_centos73
-docker run -ti -d --name foam1812 -v ${PWD}:/home/ofuser/app:rw openfoamplus/of_v1812_centos73 /bin/sh
-docker exec foam1812 /bin/sh -c "cd /home/ofuser/app; ls"
-docker exec foam1812 /bin/sh -c "source /opt/OpenFOAM/setImage_v1812.sh; cd /home/ofuser/app; source etc/bashrc; ./Allwmake -tau"
+docker pull ithacafv/openfoam1812-muq2-pytorch
+docker run -ti -d --name foam1812 -v "${PWD}":/home/ofuser/app:rw ithacafv/openfoam1812-muq2-pytorch /bin/bash
+docker exec foam1812 /bin/bash -c "cd /home/ofuser/app; ls"
+docker exec foam1812 /bin/bash -c "export MUQ_LIBRARIES=/home/Installations/MUQ_INSTALL; export MUQ_EXT_LIBRARIES=/home/Installations/MUQ_INSTALL/muq_external; export TORCH_LIBRARIES=/pytorch/torch; cd /home/ofuser/app; source /root/OpenFOAM/OpenFOAM-v1812/etc/bashrc; source etc/bashrc; ./Allwmake -taumq"
+

--- a/.compileOF1906.sh
+++ b/.compileOF1906.sh
@@ -1,4 +1,5 @@
-docker pull openfoamplus/of_v1906_centos73
-docker run -ti -d --name foam1906 -v ${PWD}:/home/ofuser/app:rw openfoamplus/of_v1906_centos73 /bin/sh
-docker exec foam1906 /bin/sh -c "cd /home/ofuser/app; ls"
-docker exec foam1906 /bin/sh -c "source /opt/OpenFOAM/setImage_v1906.sh; cd /home/ofuser/app; source etc/bashrc; ./Allwmake -tau"
+docker pull ithacafv/openfoam1906-muq2-pytorch
+docker run -ti -d --name foam1906 -v "${PWD}":/home/ofuser/app:rw ithacafv/openfoam1906-muq2-pytorch /bin/bash
+docker exec foam1906 /bin/bash -c "cd /home/ofuser/app; ls"
+docker exec foam1906 /bin/bash -c "export MUQ_LIBRARIES=/home/Installations/MUQ_INSTALL; export MUQ_EXT_LIBRARIES=/home/Installations/MUQ_INSTALL/muq_external; export TORCH_LIBRARIES=/pytorch/torch; cd /home/ofuser/app; source /root/OpenFOAM/OpenFOAM-v1906/etc/bashrc; source etc/bashrc; ./Allwmake -taumq"
+

--- a/.compileOF1912.sh
+++ b/.compileOF1912.sh
@@ -1,4 +1,5 @@
-docker pull openfoamplus/of_v1912_centos73
-docker run -ti -d --name foam1912 -v ${PWD}:/home/ofuser/app:rw openfoamplus/of_v1912_centos73 /bin/sh
-docker exec foam1912 /bin/sh -c "cd /home/ofuser/app; ls"
-docker exec foam1912 /bin/sh -c "source /opt/OpenFOAM/setImage_v1912.sh; cd /home/ofuser/app; source etc/bashrc; ./Allwmake -tau"
+docker pull ithacafv/openfoam1912-muq2-pytorch
+docker run -ti -d --name foam1912 -v "${PWD}":/home/ofuser/app:rw ithacafv/openfoam1912-muq2-pytorch /bin/bash
+docker exec foam1912 /bin/bash -c "cd /home/ofuser/app; ls"
+docker exec foam1912 /bin/bash -c "export MUQ_LIBRARIES=/home/Installations/MUQ_INSTALL; export MUQ_EXT_LIBRARIES=/home/Installations/MUQ_INSTALL/muq_external; export TORCH_LIBRARIES=/pytorch/torch; cd /home/ofuser/app; source /usr/lib/openfoam/openfoam1912/etc/bashrc; source etc/bashrc; ./Allwmake -taumq"
+

--- a/.compileOF2006.sh
+++ b/.compileOF2006.sh
@@ -1,4 +1,4 @@
-docker pull openfoamplus/of_v2006_centos73
-docker run -ti -d --name foam2006 -v ${PWD}:/home/ofuser/app:rw openfoamplus/of_v2006_centos73 /bin/sh
-docker exec foam2006 /bin/sh -c "cd /home/ofuser/app; ls"
-docker exec foam2006 /bin/sh -c "source /opt/OpenFOAM/setImage_v2006.sh; cd /home/ofuser/app; source etc/bashrc; ./Allwmake -tau"
+docker pull ithacafv/openfoam2006-muq2-pytorch
+docker run -ti -d --name foam2006 -v "${PWD}":/home/ofuser/app:rw ithacafv/openfoam2006-muq2-pytorch /bin/bash
+docker exec foam2006 /bin/bash -c "cd /home/ofuser/app; ls"
+docker exec foam2006 /bin/bash -c "export MUQ_LIBRARIES=/home/Installations/MUQ_INSTALL; export MUQ_EXT_LIBRARIES=/home/Installations/MUQ_INSTALL/muq_external; export TORCH_LIBRARIES=/pytorch/torch; cd /home/ofuser/app; source /usr/lib/openfoam/openfoam2006/etc/bashrc; source etc/bashrc; ./Allwmake -taumq"

--- a/.compileOF5.sh
+++ b/.compileOF5.sh
@@ -1,3 +1,4 @@
-source /opt/openfoam5/etc/bashrc
-source etc/bashrc
-./Allwmake -tau
+docker pull ithacafv/openfoam5-muq2-pytorch:v0
+docker run -ti -d --name foam5 -v "${PWD}":/home/ofuser/app:rw ithacafv/openfoam5-muq2-pytorch /bin/bash
+docker exec foam5 /bin/bash -c "cd /home/ofuser/app; ls"
+docker exec foam5 /bin/bash -c "export MUQ_LIBRARIES=/home/Installations/MUQ_INSTALL; export MUQ_EXT_LIBRARIES=/home/Installations/MUQ_INSTALL/muq_external; export TORCH_LIBRARIES=~/pytorch/torch; cd /home/ofuser/app; source /opt/openfoam5/etc/bashrc; source etc/bashrc; ./Allwmake -taumq"

--- a/.compileOF6.sh
+++ b/.compileOF6.sh
@@ -1,3 +1,4 @@
-source /opt/openfoam6/etc/bashrc
-source etc/bashrc
-./Allwmake -tau
+docker pull ithacafv/openfoam6-muq2-pytorch:v0
+docker run -ti -d --name foam6 -v "${PWD}":/home/ofuser/app:rw ithacafv/openfoam6-muq2-pytorch:v0 /bin/bash
+docker exec foam6 /bin/bash -c "cd /home/ofuser/app; ls"
+docker exec foam6 /bin/bash -c "export MUQ_LIBRARIES=/home/Installations/MUQ_INSTALL; export MUQ_EXT_LIBRARIES=/home/Installations/MUQ_INSTALL/muq_external; export TORCH_LIBRARIES=/pytorch/torch; cd /home/ofuser/app; source /opt/openfoam6/etc/bashrc; source etc/bashrc; ./Allwmake -taumq"

--- a/.github/workflows/of5.yml
+++ b/.github/workflows/of5.yml
@@ -15,13 +15,10 @@ jobs:
       matrix:
         include:
           - name: "OpenFOAM 5"
-            install: ./.installOF5.sh
             compile: ./.compileOF5.sh
 
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: install OF
-      run: ${{ matrix.install}}
     - name: make
       run: ${{ matrix.compile}}

--- a/.github/workflows/of6.yml
+++ b/.github/workflows/of6.yml
@@ -15,13 +15,10 @@ jobs:
       matrix:
         include:
           - name: "OpenFOAM 6"
-            install: ./.installOF6.sh
             compile: ./.compileOF6.sh
 
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: install OF
-      run: ${{ matrix.install}}
     - name: make
       run: ${{ matrix.compile}}

--- a/.installOF5.sh
+++ b/.installOF5.sh
@@ -1,5 +1,0 @@
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6C0DAC728B29D817
-sudo apt-get update --fix-missing
-sudo add-apt-repository http://dl.openfoam.org/ubuntu
-sudo apt-get update --fix-missing
-sudo apt-get -y install -qq openfoam5 --allow-unauthenticated

--- a/.installOF6.sh
+++ b/.installOF6.sh
@@ -1,5 +1,0 @@
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6C0DAC728B29D817
-sudo apt-get update --fix-missing
-sudo add-apt-repository http://dl.openfoam.org/ubuntu
-sudo apt-get update --fix-missing
-sudo apt-get -y install -qq openfoam6 --allow-unauthenticated


### PR DESCRIPTION
This PR modifies the compilation tests performed at each pull request to compile also parts of the code that depend on  MUQ2 and PYTORCH.
To do it, we created docker images for all the versions of OpenFOAM with MUQ2 and PYTORCH also compiled (see the [ithacafv Docker repository](https://hub.docker.com/u/ithacafv)). Then, the github actions at each PR create a Docker container for each of these images and compile ITHACA with the "-taumq" flag.