### PR TITLE
Add a method to compute L2 projection forces

### DIFF
--- a/src/ITHACA_FOMPROBLEMS/steadyNS/steadyNS.H
+++ b/src/ITHACA_FOMPROBLEMS/steadyNS/steadyNS.H
@@ -615,6 +615,17 @@ class steadyNS: public reductionProblem
         ///
         void forcesMatrices(label nModes);
 
+
+        //--------------------------------------------------------------------------
+        /// @brief      Method to reconstruct the forces using velocity and pressure coefficients
+        ///
+        /// @param[in]  velCoeffs       The velocity coefficients matrix
+        /// @param[in]  pressureCoeffs  The pressure coefficients matrix
+        /// @param[in]  folder          The folder where to output the forces matrices
+        ///
+        void reconstructLiftAndDrag(const Eigen::MatrixXd& velCoeffs,
+                                    const Eigen::MatrixXd& pressureCoeffs, fileName folder);
+
         //--------------------------------------------------------------------------
         /// @brief      Export convective term as a tensor
         ///


### PR DESCRIPTION
Add a method to compute L2 projection forces. The method takes as input the coefficient matrices of velocity and pressure with the number of columns of each matrix corresponding to the number of POD modes involved in the computations.