### PR TITLE
FIX: fixed error in assert on computeLift

### DIFF
--- a/src/ITHACA_FOMPROBLEMS/reductionProblem/reductionProblemTemplates.C
+++ b/src/ITHACA_FOMPROBLEMS/reductionProblem/reductionProblemTemplates.C
@@ -53,7 +53,7 @@ void reductionProblem::computeLift(T& Lfield, T& liftfield, T& omfield)
         area = gSum(Lfield[0].mesh().magSf().boundaryField()[p]);
         u_lf = gSum(liftfield[k].mesh().magSf().boundaryField()[p] *
                     liftfield[k].boundaryField()[p]).component(l) / area;
-        M_Assert(abs(u_lf) > 1e-5,
+        M_Assert(std::abs(u_lf) > 1e-5,
                  "The lift cannot be computed. Please, check your inletIndex definition");
 
         for (label j = 0; j < Lfield.size(); j++)


### PR DESCRIPTION
The assert in `computeLift` goes through for some compilations and examples, e.g. in 17YJunction tutorial `u_lf` is 0.7615 but `abs(u_lf)` may return 0 by doing an implicit conversion to integer. Fixing it with `std::abs`.