### PR TITLE
FIX: fixed error running UnsteadyBB tutorial with PPE stabilization 

### DIFF
--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyBB/ReducedUnsteadyBB.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyBB/ReducedUnsteadyBB.C
@@ -83,6 +83,9 @@ ReducedUnsteadyBB::ReducedUnsteadyBB(UnsteadyBB& FOMproblem)
     newton_object_sup = newton_unsteadyBB_sup(Nphi_u + Nphi_prgh + Nphi_t,
                         Nphi_u + Nphi_prgh + Nphi_t,
                         FOMproblem);
+    newton_object_PPE = newton_unsteadyBB_PPE(Nphi_u + Nphi_prgh + Nphi_t,
+                        Nphi_u + Nphi_prgh + Nphi_t,
+                        FOMproblem);
 }
 
 

--- a/tutorials/CFD/11UnsteadyBBOpen/11UnsteadyBBOpen.C
+++ b/tutorials/CFD/11UnsteadyBBOpen/11UnsteadyBBOpen.C
@@ -203,7 +203,11 @@ int main(int argc, char* argv[])
     int NmodesPrghproj = para->ITHACAdict->lookupOrDefault<int>("NmodesPrghproj",
                          5);
     int NmodesTproj   = para->ITHACAdict->lookupOrDefault<int>("NmodesTproj", 5);
-    int NmodesSUPproj = para->ITHACAdict->lookupOrDefault<int>("NmodesSUPproj", 5);
+    int NmodesSUPproj = 0;
+    if (stabilization == "supremizer")
+    {
+        NmodesSUPproj = para->ITHACAdict->lookupOrDefault<int>("NmodesSUPproj", 5);
+    }
     int NmodesOut     = para->ITHACAdict->lookupOrDefault<int>("NmodesOut", 15);
     // Set the number of parameters
     example.Pnumber = 1;

--- a/tutorials/CFD/11UnsteadyBBOpen/system/ITHACAdict
+++ b/tutorials/CFD/11UnsteadyBBOpen/system/ITHACAdict
@@ -17,6 +17,9 @@ FoamFile
 // EigenValue solver, can be eigen or spectra
 EigenSolver eigen;
 
+// Stabilization, can be supremizer or PPE
+Stabilization PPE;
+
 // Number of modes to output and to use for projection
 NmodesUout 15;
 NmodesUproj 15;


### PR DESCRIPTION
Fixed errors in #405. Note that changes in `11UnsteadyOpen.C` were for selecting the stabilization method from the dictionary and reproduce these error in the tutorial.