### PR TITLE
ENH: Updates in DEIM, ITHACAPOD, ITHACAassign, ITHACAparameters, ITHACAstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,157 @@ tutorials_dev
 *.foam
 **/__pycache__
 *.npy
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/src/ITHACA_CORE/Containers/Modes.H
+++ b/src/ITHACA_CORE/Containers/Modes.H
@@ -145,7 +145,7 @@ class Modes : public PtrList<GeometricField<Type, PatchField, GeoMesh>>
         /// @param[in]  numberOfModes  The number of modes used to project. If
         ///                            not given it will use all the available
         ///                            ones.
-        /// @param[in]  projType       The projection type, it can be Galerkin "G" or Petrov-Galerkin "PG"
+        /// @param[in]  projType       The projection type, it can be Galerkin "G", Petrov-Galerkin "PG" or "F" Frobenius
         /// @param[in]  Af             The system matrix used in case of Petrov-Galerkin projection
         ///
         /// @return     An Eigen MatricxXd list.
@@ -159,7 +159,7 @@ class Modes : public PtrList<GeometricField<Type, PatchField, GeoMesh>>
         ///
         /// @param      field          The field one wants to project
         /// @param[in]  numberOfModes  The number of modes
-        /// @param[in]  projType       The projection type, it can be Galerkin "G" or Petrov-Galerkin "PG"
+        /// @param[in]  projType       The projection type, it can be Galerkin "G", Petrov-Galerkin "PG" or "F" Frobenius
         /// @param      Af             The system matrix used in case of Petrov-Galerkin projection
         ///
         /// @return     The projected snapshot

--- a/src/ITHACA_CORE/Foam2Eigen/Foam2Eigen.C
+++ b/src/ITHACA_CORE/Foam2Eigen/Foam2Eigen.C
@@ -1004,3 +1004,33 @@ template List<int> Foam2Eigen::EigenMatrix2List (
     Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> matrix );
 template List<double> Foam2Eigen::EigenMatrix2List (
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> matrix );
+
+template<>
+Eigen::MatrixXd Foam2Eigen::field2Eigen(const List<vector>& field)
+{
+    Eigen::MatrixXd out;
+    out.resize(label(field.size() * 3), 1);
+
+    for (label l = 0; l < field.size(); l++)
+    {
+        out(l, 0) = field[l][0];
+        out(field.size() +  l, 0 ) = field[l][1];
+        out(2 * field.size() + l, 0 ) = field[l][2];
+    }
+
+    return out;
+}
+
+template<>
+Eigen::MatrixXd Foam2Eigen::field2Eigen(const List<scalar>& field)
+{
+    Eigen::MatrixXd out;
+    out.resize(label(field.size()), 1);
+
+    for (label l = 0; l < field.size(); l++)
+    {
+        out(l, 0) = field[l];
+    }
+
+    return out;
+}

--- a/src/ITHACA_CORE/Foam2Eigen/Foam2Eigen.H
+++ b/src/ITHACA_CORE/Foam2Eigen/Foam2Eigen.H
@@ -419,5 +419,17 @@ class Foam2Eigen
         template <class type_matrix>
         static List<type_matrix> EigenMatrix2List (
             Eigen::Matrix<type_matrix, Eigen::Dynamic, Eigen::Dynamic> matrix );
+
+        //----------------------------------------------------------------------
+        /// @brief      Function to convert an OpenFOAM list to an Eigen Matrix
+        ///
+        /// @param[in]  list       The OpenFOAM list
+        ///
+        /// @tparam     type_list  The type of the list, only scalar and vector are supported
+        ///
+        /// @return     An Eigen::MatrixXd Matrix containing the OpenFOAM values
+        ///
+        template <class type_list>
+        static Eigen::MatrixXd field2Eigen(const List<type_list>& list);
 };
 #endif

--- a/src/ITHACA_CORE/ITHACAPOD/ITHACAPOD.H
+++ b/src/ITHACA_CORE/ITHACAPOD/ITHACAPOD.H
@@ -252,11 +252,10 @@ void exportcumEigenvalues(scalarField cumEigenvalues,  fileName name,
 ///
 /// @return     Type             the POD modes
 ///
-template<typename Type>
-PtrList<GeometricField<Type, fvPatchField, volMesh>> DEIMmodes(
-            PtrList<GeometricField<Type, fvPatchField, volMesh>>& SnapShotsMatrix,
-            label nmodes,
-            word FunctionName, word FieldName);
+template<class Type, template<class> class PatchField, class GeoMesh>
+PtrList<GeometricField<Type, PatchField, GeoMesh>> DEIMmodes(
+            PtrList<GeometricField<Type, PatchField, GeoMesh>>& SnapShotsMatrix,
+            label nmodes, word FunctionName, word FieldName);
 
 //------------------------------------------------------------------------------
 /// @brief      Get the DEIM modes for a generic non-parametrized matrix coming

--- a/src/ITHACA_CORE/ITHACAstream/ITHACAparameters.C
+++ b/src/ITHACA_CORE/ITHACAstream/ITHACAparameters.C
@@ -37,6 +37,7 @@ ITHACAparameters::ITHACAparameters(fvMesh& mesh, Time& localTime)
     exportMatlab = ITHACAdict->lookupOrDefault<bool>("exportMatlab", 0);
     exportTxt = ITHACAdict->lookupOrDefault<bool>("exportTxt", 0);
     debug = ITHACAdict->lookupOrDefault<bool>("debug", 0);
+    warnings = ITHACAdict->lookupOrDefault<bool>("warnings", 0);
 }
 
 ITHACAparameters* ITHACAparameters::getInstance(fvMesh& mesh,

--- a/src/ITHACA_CORE/ITHACAstream/ITHACAparameters.H
+++ b/src/ITHACA_CORE/ITHACAstream/ITHACAparameters.H
@@ -54,6 +54,7 @@ class ITHACAparameters
         bool exportMatlab;
         bool exportTxt;
         bool debug;
+        bool warnings;
 
         /// type of output format can be fixed or scientific
         std::_Ios_Fmtflags outytpe;

--- a/src/ITHACA_CORE/ITHACAutilities/ITHACAassign.H
+++ b/src/ITHACA_CORE/ITHACAutilities/ITHACAassign.H
@@ -267,7 +267,6 @@ template<typename Type>
 void assignZeroDirichlet(GeometricField<Type, fvPatchField,
                          volMesh>& field);
 
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcomment"
 //------------------------------------------------------------------------------
@@ -368,6 +367,36 @@ void assignMixedBC(GeometricField<Type, fvPatchField, volMesh>& field,
 template<typename Type>
 void normalizeFields(
     PtrList<GeometricField<Type, fvPatchField, volMesh>>& fields);
+
+//------------------------------------------------------------------------------
+/// @brief      /// @brief      Gets the values from a list of indices
+///
+/// @param      field    The field from which you want to extract the values
+/// @param      indices  The indices at the point
+/// @param      xyz      Definition of the x, y, z coordinate of the value you want to extract 0 for x, 1 for y, 2 for z
+///
+/// @tparam     Type     type of the Field can be Scalar or Vector
+///
+/// @return     The values.
+///
+template<typename Type>
+Eigen::MatrixXd getValues(GeometricField<Type, fvPatchField,
+                          volMesh>& field, labelList& indices, labelList* xyz = NULL);
+
+//------------------------------------------------------------------------------
+/// @brief      Gets the values from a list of indices
+///
+/// @param      field    The field
+/// @param      indices  The indices
+/// @param      xyz      The xyz
+///
+/// @tparam     Type     { description }
+///
+/// @return     The values.
+///
+template<typename Type>
+Eigen::MatrixXd getValues(PtrList<GeometricField<Type, fvPatchField,
+                          volMesh>>& field, labelList& indices, labelList* xyz = NULL);
 
 }
 

--- a/src/ITHACA_CORE/ITHACAutilities/ITHACAerror.C
+++ b/src/ITHACA_CORE/ITHACAutilities/ITHACAerror.C
@@ -76,10 +76,41 @@ double LinfNorm(GeometricField<vector, fvPatchField, volMesh>& field)
 
 template<class Type, template<class> class PatchField, class GeoMesh>
 double errorFrobRel(GeometricField<Type, PatchField, GeoMesh>& field1,
-                    GeometricField<Type, PatchField, GeoMesh>& field2)
+                    GeometricField<Type, PatchField, GeoMesh>& field2, List<label>* labels)
 {
     double err;
-    GeometricField<Type, PatchField, GeoMesh> errField = (field1 - field2).ref();
+    autoPtr<GeometricField<Type, PatchField, GeoMesh>> errField;
+    autoPtr<GeometricField<Type, PatchField, GeoMesh>> field1_S;
+    autoPtr<GeometricField<Type, PatchField, GeoMesh>> field2_S;
+    autoPtr<fvMeshSubset> submesh;
+
+    if (labels != NULL)
+    {
+        submesh = autoPtr<fvMeshSubset>(new fvMeshSubset(field1.mesh()));
+#if OPENFOAM >= 1812
+        submesh->setCellSubset(*labels);
+#else
+        submesh->setLargeCellSubset(*labels);
+#endif
+        GeometricField<Type, PatchField, GeoMesh> field1tmp(submesh->interpolate(
+                    field1));
+        GeometricField<Type, PatchField, GeoMesh> field2tmp(submesh->interpolate(
+                    field2));
+        field1_S = autoPtr<GeometricField<Type, PatchField, GeoMesh>>
+                   (new GeometricField<Type, PatchField, GeoMesh>(field1tmp.clone()));
+        field2_S = autoPtr<GeometricField<Type, PatchField, GeoMesh>>
+                   (new GeometricField<Type, PatchField, GeoMesh>(field2tmp.clone()));
+    }
+    else
+    {
+        field1_S = autoPtr<GeometricField<Type, PatchField, GeoMesh>>
+                   (new GeometricField<Type, PatchField, GeoMesh>(field1));
+        field2_S = autoPtr<GeometricField<Type, PatchField, GeoMesh>>
+                   (new GeometricField<Type, PatchField, GeoMesh>(field2));
+    }
+
+    errField = autoPtr<GeometricField<Type, PatchField, GeoMesh>>
+               (new GeometricField<Type, PatchField, GeoMesh>(field1_S() - field2_S()));
 
     if (frobNorm(field1) <= 1e-6)
     {
@@ -87,7 +118,7 @@ double errorFrobRel(GeometricField<Type, PatchField, GeoMesh>& field1,
     }
     else
     {
-        err = frobNorm(errField) / frobNorm(field1);
+        err = frobNorm(errField()) / frobNorm(field1_S());
     }
 
     return err;
@@ -96,30 +127,62 @@ double errorFrobRel(GeometricField<Type, PatchField, GeoMesh>& field1,
 
 template double errorFrobRel(GeometricField<scalar, fvPatchField, volMesh>&
                              field1,
-                             GeometricField<scalar, fvPatchField, volMesh>& field2);
+                             GeometricField<scalar, fvPatchField, volMesh>& field2, List<label>* labels);
 template double errorFrobRel(GeometricField<vector, fvPatchField, volMesh>&
                              field1,
-                             GeometricField<vector, fvPatchField, volMesh>& field2);
+                             GeometricField<vector, fvPatchField, volMesh>& field2, List<label>* labels);
 
 template double errorFrobRel(GeometricField<scalar, fvsPatchField, surfaceMesh>&
                              field1,
-                             GeometricField<scalar, fvsPatchField, surfaceMesh>& field2);
+                             GeometricField<scalar, fvsPatchField, surfaceMesh>& field2,
+                             List<label>* labels);
 
 
 template<typename T>
 double errorLinfRel(GeometricField<T, fvPatchField, volMesh>& field1,
-                    GeometricField<T, fvPatchField, volMesh>& field2)
+                    GeometricField<T, fvPatchField, volMesh>& field2, List<label>* labels)
 {
     double err;
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> errField;
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> field1_S;
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> field2_S;
+    autoPtr<fvMeshSubset> submesh;
 
-    if (LinfNorm(field1) <= 1e-6)
+    if (labels != NULL)
+    {
+        submesh = autoPtr<fvMeshSubset>(new fvMeshSubset(field1.mesh()));
+#if OPENFOAM >= 1812
+        submesh->setCellSubset(*labels);
+#else
+        submesh->setLargeCellSubset(*labels);
+#endif
+        GeometricField<T, fvPatchField, volMesh> field1tmp(submesh->interpolate(
+                    field1));
+        GeometricField<T, fvPatchField, volMesh> field2tmp(submesh->interpolate(
+                    field2));
+        field1_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field1tmp.clone()));
+        field2_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field2tmp.clone()));
+    }
+    else
+    {
+        field1_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field1));
+        field2_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field2));
+    }
+
+    errField = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+               (new GeometricField<T, fvPatchField, volMesh>(field1_S() - field2_S()));
+
+    if (LinfNorm(field1_S()) <= 1e-6)
     {
         err = 0;
     }
     else
     {
-        GeometricField<T, fvPatchField, volMesh> fieldDiff = (field1 - field2).ref();
-        err = LinfNorm(fieldDiff) / LinfNorm(field1);
+        err = LinfNorm(errField()) / LinfNorm(field1_S());
     }
 
     return err;
@@ -128,10 +191,10 @@ double errorLinfRel(GeometricField<T, fvPatchField, volMesh>& field1,
 
 template double errorLinfRel(GeometricField<scalar, fvPatchField, volMesh>&
                              field1,
-                             GeometricField<scalar, fvPatchField, volMesh>& field2);
+                             GeometricField<scalar, fvPatchField, volMesh>& field2, List<label>* labels);
 template double errorLinfRel(GeometricField<vector, fvPatchField, volMesh>&
                              field1,
-                             GeometricField<vector, fvPatchField, volMesh>& field2);
+                             GeometricField<vector, fvPatchField, volMesh>& field2, List<label>* labels);
 
 template<>
 double errorL2Abs(GeometricField<vector, fvPatchField, volMesh>& field1,
@@ -157,24 +220,55 @@ double errorL2Abs(GeometricField<scalar, fvPatchField, volMesh>& field1,
 
 template<typename T>
 double errorL2Abs(GeometricField<T, fvPatchField, volMesh>& field1,
-                  GeometricField<T, fvPatchField, volMesh>& field2)
+                  GeometricField<T, fvPatchField, volMesh>& field2, List<label>* labels)
 {
-    GeometricField<T, fvPatchField, volMesh> errField = (field1 - field2).ref();
-    double err = L2Norm(errField);
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> errField;
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> field1_S;
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> field2_S;
+    autoPtr<fvMeshSubset> submesh;
+
+    if (labels != NULL)
+    {
+        submesh = autoPtr<fvMeshSubset>(new fvMeshSubset(field1.mesh()));
+#if OPENFOAM >= 1812
+        submesh->setCellSubset(*labels);
+#else
+        submesh->setLargeCellSubset(*labels);
+#endif
+        GeometricField<T, fvPatchField, volMesh> field1tmp(submesh->interpolate(
+                    field1));
+        GeometricField<T, fvPatchField, volMesh> field2tmp(submesh->interpolate(
+                    field2));
+        field1_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field1tmp.clone()));
+        field2_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field2tmp.clone()));
+    }
+    else
+    {
+        field1_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field1));
+        field2_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field2));
+    }
+
+    errField = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+               (new GeometricField<T, fvPatchField, volMesh>(field1_S() - field2_S()));
+    double err = L2Norm(errField());
     return err;
 }
 
 template double errorL2Abs(GeometricField<scalar, fvPatchField, volMesh>&
                            field1,
-                           GeometricField<scalar, fvPatchField, volMesh>& field2);
+                           GeometricField<scalar, fvPatchField, volMesh>& field2, List<label>* labels);
 template double errorL2Abs(GeometricField<vector, fvPatchField, volMesh>&
                            field1,
-                           GeometricField<vector, fvPatchField, volMesh>& field2);
+                           GeometricField<vector, fvPatchField, volMesh>& field2, List<label>* labels);
 
 template<typename T>
 Eigen::MatrixXd errorFrobRel(PtrList<GeometricField<T, fvPatchField, volMesh>>&
                              fields1,
-                             PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2)
+                             PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2, List<label>* labels)
 {
     Eigen::VectorXd err;
 
@@ -188,7 +282,7 @@ Eigen::MatrixXd errorFrobRel(PtrList<GeometricField<T, fvPatchField, volMesh>>&
 
     for (label k = 0; k < fields1.size(); k++)
     {
-        err(k, 0) = errorFrobRel(fields1[k], fields2[k]);
+        err(k, 0) = errorFrobRel(fields1[k], fields2[k], labels);
         Info << " Error is " << err[k] << endl;
     }
 
@@ -197,10 +291,12 @@ Eigen::MatrixXd errorFrobRel(PtrList<GeometricField<T, fvPatchField, volMesh>>&
 
 template Eigen::MatrixXd errorFrobRel(
     PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields1,
-    PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields2);
+    PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields2,
+    List<label>* labels);
 template Eigen::MatrixXd errorFrobRel(
     PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields1,
-    PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields2);
+    PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields2,
+    List<label>* labels);
 
 
 template<typename T>
@@ -237,7 +333,7 @@ template Eigen::MatrixXd errorL2Abs(
 template<typename T>
 Eigen::MatrixXd errorL2Abs(PtrList<GeometricField<T, fvPatchField, volMesh>>&
                            fields1,
-                           PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2)
+                           PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2, List<label>* labels)
 {
     Eigen::VectorXd err;
 
@@ -251,7 +347,7 @@ Eigen::MatrixXd errorL2Abs(PtrList<GeometricField<T, fvPatchField, volMesh>>&
 
     for (label k = 0; k < fields1.size(); k++)
     {
-        err(k, 0) = errorL2Abs(fields1[k], fields2[k]);
+        err(k, 0) = errorL2Abs(fields1[k], fields2[k], labels);
         Info << " Error is " << err[k] << endl;
     }
 
@@ -260,17 +356,50 @@ Eigen::MatrixXd errorL2Abs(PtrList<GeometricField<T, fvPatchField, volMesh>>&
 
 template Eigen::MatrixXd errorL2Abs(
     PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields1,
-    PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields2);
+    PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields2,
+    List<label>* labels);
 template Eigen::MatrixXd errorL2Abs(
     PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields1,
-    PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields2);
+    PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields2,
+    List<label>* labels);
 
 template<typename T>
 double errorL2Rel(GeometricField<T, fvPatchField, volMesh>& field1,
-                  GeometricField<T, fvPatchField, volMesh>& field2)
+                  GeometricField<T, fvPatchField, volMesh>& field2, List<label>* labels)
 {
     double err;
-    GeometricField<T, fvPatchField, volMesh> errField = (field1 - field2).ref();
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> errField;
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> field1_S;
+    autoPtr<GeometricField<T, fvPatchField, volMesh>> field2_S;
+    autoPtr<fvMeshSubset> submesh;
+
+    if (labels != NULL)
+    {
+        submesh = autoPtr<fvMeshSubset>(new fvMeshSubset(field1.mesh()));
+#if OPENFOAM >= 1812
+        submesh->setCellSubset(*labels);
+#else
+        submesh->setLargeCellSubset(*labels);
+#endif
+        GeometricField<T, fvPatchField, volMesh> field1tmp(submesh->interpolate(
+                    field1));
+        GeometricField<T, fvPatchField, volMesh> field2tmp(submesh->interpolate(
+                    field2));
+        field1_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field1tmp.clone()));
+        field2_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field2tmp.clone()));
+    }
+    else
+    {
+        field1_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field1));
+        field2_S = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+                   (new GeometricField<T, fvPatchField, volMesh>(field2));
+    }
+
+    errField = autoPtr<GeometricField<T, fvPatchField, volMesh>>
+               (new GeometricField<T, fvPatchField, volMesh>(field1_S() - field2_S()));
 
     if (L2Norm(field1) <= 1e-6)
     {
@@ -278,8 +407,8 @@ double errorL2Rel(GeometricField<T, fvPatchField, volMesh>& field1,
     }
     else
     {
-        err = L2Norm(errField) / L2Norm(
-                  field1);
+        err = L2Norm(errField()) / L2Norm(
+                  field1_S());
     }
 
     return err;
@@ -287,14 +416,15 @@ double errorL2Rel(GeometricField<T, fvPatchField, volMesh>& field1,
 
 template double errorL2Rel(GeometricField<scalar, fvPatchField, volMesh>&
                            field1,
-                           GeometricField<scalar, fvPatchField, volMesh>& field2);
+                           GeometricField<scalar, fvPatchField, volMesh>& field2, List<label>* labels);
 template double errorL2Rel(GeometricField<vector, fvPatchField, volMesh>&
                            field1,
-                           GeometricField<vector, fvPatchField, volMesh>& field2);
+                           GeometricField<vector, fvPatchField, volMesh>& field2, List<label>* labels);
 
 template<typename T>
 Eigen::MatrixXd errorL2Rel(PtrList<GeometricField<T, fvPatchField, volMesh>>&
-                           fields1, PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2)
+                           fields1, PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2,
+                           List<label>* labels)
 {
     Eigen::VectorXd err;
 
@@ -308,7 +438,7 @@ Eigen::MatrixXd errorL2Rel(PtrList<GeometricField<T, fvPatchField, volMesh>>&
 
     for (label k = 0; k < fields1.size(); k++)
     {
-        err(k, 0) = errorL2Rel(fields1[k], fields2[k]);
+        err(k, 0) = errorL2Rel(fields1[k], fields2[k], labels);
         Info << " Error is " << err[k] << endl;
     }
 
@@ -317,10 +447,12 @@ Eigen::MatrixXd errorL2Rel(PtrList<GeometricField<T, fvPatchField, volMesh>>&
 
 template Eigen::MatrixXd errorL2Rel(
     PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields1,
-    PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields2);
+    PtrList<GeometricField<scalar, fvPatchField, volMesh>>& fields2,
+    List<label>* labels);
 template Eigen::MatrixXd errorL2Rel(
     PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields1,
-    PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields2);
+    PtrList<GeometricField<vector, fvPatchField, volMesh>>& fields2,
+    List<label>* labels);
 
 template<>
 double H1Seminorm(GeometricField<scalar, fvPatchField, volMesh>& field)

--- a/src/ITHACA_CORE/ITHACAutilities/ITHACAerror.H
+++ b/src/ITHACA_CORE/ITHACAutilities/ITHACAerror.H
@@ -54,56 +54,61 @@ using namespace std::placeholders;
 
 namespace ITHACAutilities
 {
-//--------------------------------------------------------------------------
-/// Computes the relative error between two Fields in the Frobenius norm
-///
-/// @param      field1     The reference field to which the norm is computed
-/// @param      field2     The field for which the error is computed
-///
-/// @tparam     TypeField  type of field can be scalar or vector
-///
-/// @return     The Frobenius norm of the relative error.
-///
 
+//------------------------------------------------------------------------------
+/// @brief      Computes the relative error between two Fields in the Frobenius norm
+///
+/// @param      field1      The reference field to which the norm is computed
+/// @param      field2      The field for which the error is computed
+/// @param      labels      (optional) a list of labels with the indices were you want to compute the error
+///
+/// @tparam     Type        Type of field, can be scalar or vector
+/// @tparam     PatchField  Type of PatchField, surface or volumetric
+/// @tparam     GeoMesh     Type of Mesh, surface or volumetric
+///
+/// @return     Frobenius norm of the relative error.
+///
 template<class Type, template<class> class PatchField, class GeoMesh>
 double errorFrobRel(GeometricField<Type, PatchField, GeoMesh>& field1,
-                    GeometricField<Type, PatchField, GeoMesh>& field2);
+                    GeometricField<Type, PatchField, GeoMesh>& field2, List<label>* labels = NULL);
 
 //--------------------------------------------------------------------------
-/// Computes the relative error between two geometric Fields in L2 norm
+/// @brief      Computes the relative error between two geometric Fields in L2 norm
 ///
-/// @param[in]  field1  The field 1
-/// @param[in]  field2  The field 2
+/// @param[in]  field1      The reference field to which the norm is computed
+/// @param[in]  field2      The field for which the error is computed
+/// @param[in]  labels      (optional) a list of labels with the indices were you want to compute the error
 ///
-/// @tparam     TypeField   type of field
+/// @tparam     T   type of field
 ///
 /// @return     L2 norm of the relative error.
 ///
 template<typename T>
 double errorL2Rel(GeometricField<T, fvPatchField, volMesh>& field1,
-                  GeometricField<T, fvPatchField, volMesh>& field2);
+                  GeometricField<T, fvPatchField, volMesh>& field2, List<label>* labels = NULL);
 
 //--------------------------------------------------------------------------
-/// Computes the relative error between two geometric Fields in Linf norm
+/// @brief      Computes the relative error between two geometric Fields in Linf norm
 ///
-/// @param[in]  field1  The field 1
-/// @param[in]  field2  The field 2
+/// @param[in]  field1      The reference field to which the norm is computed
+/// @param[in]  field2      The field for which the error is computed
+/// @param[in]  labels      (optional) a list of labels with the indices were you want to compute the error
 ///
-/// @tparam     TypeField   type of field
+/// @tparam     T   type of field
 ///
 /// @return     Linf norm of the relative error.
 ///
 template<typename T>
 double errorLinfRel(GeometricField<T, fvPatchField, volMesh>& field1,
-                    GeometricField<T, fvPatchField, volMesh>& field2);
+                    GeometricField<T, fvPatchField, volMesh>& field2, List<label>* labels = NULL);
 
 //--------------------------------------------------------------------------
-/// Computes the relative error between two geometric Fields in
-/// L2 norm, given the mesh volumes field
+/// @brief      Computes the absolute error between two geometric Fields in
+///             L2 norm, given the mesh volumes field
 ///
-/// @param[in]  field1  The field 1
-/// @param[in]  field2  The field 2
-/// @param[in]  Volumes  The field containing the volumes of the mesh cells
+/// @param[in]  field1      The reference field to which the norm is computed
+/// @param[in]  field2      The field for which the error is computed
+/// @param[in]  labels      (optional) a list of labels with the indices were you want to compute the error
 ///
 /// @tparam     T   type of field
 ///
@@ -114,48 +119,53 @@ double errorL2Abs(GeometricField<T, fvPatchField, volMesh>& field1,
                   GeometricField<T, fvPatchField, volMesh>& field2, volScalarField& Volumes);
 
 //--------------------------------------------------------------------------
-/// Computes the absolute error between two Fields in L2 norm
+/// @brief      Computes the absolute error between two Fields in L2 norm
 ///
-/// @param[in]  field1  The field 1
-/// @param[in]  field2  The field 2
+/// @param[in]  field1      The reference field to which the norm is computed
+/// @param[in]  field2      The field for which the error is computed
+/// @param[in]  labels      (optional) a list of labels with the indices were you want to compute the error
 ///
-/// @tparam     TypeField   type of field
+/// @tparam     T   type of field
 ///
 /// @return     L2 norm of the absolute error.
 ///
 template<typename T>
 double errorL2Abs(GeometricField<T, fvPatchField, volMesh>& field1,
-                  GeometricField<T, fvPatchField, volMesh>& field2);
+                  GeometricField<T, fvPatchField, volMesh>& field2, List<label>* labels = NULL);
 
 //--------------------------------------------------------------------------
-/// Computes the relative error in L2 norm between two lists of fields
+/// @brief      Computes the relative error in L2 norm between two lists of fields
 ///
-/// @param      fields1  The reference fields to which the norm is computed
-/// @param      fields2  The fields for which the error is computed
+/// @param[in]  field1      The reference field to which the norm is computed
+/// @param[in]  field2      The field for which the error is computed
+/// @param[in]  labels      (optional) a list of labels with the indices were you want to compute the error
 ///
-/// @tparam     TypeField   type of field
+/// @tparam     T   type of field
 ///
 /// @return     Column vector, in each row the L2 norm of the relative error.
 ///
 template<typename T>
 Eigen::MatrixXd errorL2Rel(PtrList<GeometricField<T, fvPatchField, volMesh>>&
                            fields1,
-                           PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2);
+                           PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2,
+                           List<label>* labels = NULL);
 
 //--------------------------------------------------------------------------
-/// Computes the relative error in the Frobenius norm between two lists of fields
+/// @brief      Computes the relative error in the Frobenius norm between two lists of fields
 ///
-/// @param      fields1  The reference fields to which the norm is computed
-/// @param      fields2  The fields for which the error is computed
+/// @param[in]  field1      The reference field to which the norm is computed
+/// @param[in]  field2      The field for which the error is computed
+/// @param[in]  labels      (optional) a list of labels with the indices were you want to compute the error
 ///
-/// @tparam     TypeField   type of field
+/// @tparam     T   type of field
 ///
 /// @return     Column vector, in each row the Frobenius norm of the relative error.
 ///
 template<typename T>
 Eigen::MatrixXd errorFrobRel(PtrList<GeometricField<T, fvPatchField, volMesh>>&
                              fields1,
-                             PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2);
+                             PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2,
+                             List<label>* labels = NULL);
 
 //--------------------------------------------------------------------------
 /// Computes the relative error in L2 norm between two lists of Fields
@@ -176,19 +186,21 @@ Eigen::MatrixXd errorL2Abs(
     PtrList<volScalarField>& Volumes);
 
 //--------------------------------------------------------------------------
-/// Computes the absolute error in L2 norm between two lists of Fields
+/// @brief      Computes the absolute error in L2 norm between two lists of Fields
 ///
-/// @param[in]  fields1  The fields 1, scalar or vector
-/// @param[in]  fields2  The fields 2, scalar or vector
+/// @param[in]  field1      The reference field to which the norm is computed
+/// @param[in]  field2      The field for which the error is computed
+/// @param[in]  labels      (optional) a list of labels with the indices were you want to compute the error
 ///
-/// @tparam     TypeField   type of field
+/// @tparam     T   type of field
 ///
-/// @return     olumn vector, in each row the L2 norm of the absolute error.
+/// @return     column vector, in each row the L2 norm of the absolute error.
 ///
 template<typename T>
 Eigen::MatrixXd errorL2Abs(PtrList<GeometricField<T, fvPatchField, volMesh>>&
                            fields1,
-                           PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2);
+                           PtrList<GeometricField<T, fvPatchField, volMesh>>& fields2,
+                           List<label>* labels = NULL);
 
 //------------------------------------------------------------------------------
 /// Evaluate the L2 norm of a geometric field

--- a/src/ITHACA_DEIM/DEIM.H
+++ b/src/ITHACA_DEIM/DEIM.H
@@ -148,6 +148,7 @@ class DEIM
         /// Definition of the x, y, z coordinate of the identified element in the matrix or source term
         /// 0 for x, 1 for y, 2 for z
         ///@{
+        autoPtr<IOList<label>> xyz;
         autoPtr<IOList<label>> xyz_Arow;
         autoPtr<IOList<label>> xyz_Acol;
         autoPtr<IOList<label>> xyz_B;
@@ -296,6 +297,14 @@ class DEIM
         /// @return     The number of cells
         ///
         label getNcells(label sizeM);
+
+        //----------------------------------------------------------------------
+        /// @brief      Function to set the magic points externally
+        ///
+        /// @param      newMagicPoints  The new magic points
+        /// @param      newxyz          The new xyz coordinates in case of a volVectorField. In case of a volScalarField needs to be of the same dimension of magicPoints and full or zeros
+        ///
+        void setMagicPoints(labelList& newMagicPoints, labelList& newxyz);
 
 };
 


### PR DESCRIPTION
Updated the function to compute the DEIM modes and make it uniform w.r.t. to the way modes are computed by other ITHACAPOD functions. Added warnings variable in ITHACAparameters to suppress warnings. Changed warnings in ITHACAassing using OF stream functionalities and included the possibility to skip the warning message. Added possibility to use also the Frobenius norm in the computation of the projection of a field on the modes in the  Modes class. Added function to convert an OpenFOAM list to an Eigen::MatrixXd object. Added a function inside the DEIM class to eventually set externally the magic points.