### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cd ~
 ```
 Now you can clone the **ITHACA-FV** repository inside the selected folder
 ```
-git clone https://github.com/mathLab/ITHACA-FV
+git clone --depth 1 https://github.com/mathLab/ITHACA-FV
 ```
 and you can compile **ITHACA-FV** by navigating inside the src folder, sourcing the bashrc file of ITHACA-FV and compiling using wmake:
 ```


### PR DESCRIPTION
Adding "--depth 1" to the "git clone" command in the installation instructions, would reduce the folder size (I believe it was from 400MB to 40MB) for those who only wants to use the ITHACA-FV without the dev branches.