### PR TITLE
Singularity Implementation via Docker and Defination file, with GitHub actions

### DIFF
--- a/.github/workflows/Singularity_from_def.yml
+++ b/.github/workflows/Singularity_from_def.yml
@@ -1,0 +1,36 @@
+name: Singularity_from_Defination_file
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  singularity-from-defination-file:
+    runs-on: ubuntu-latest
+    steps:
+    
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - uses: eWaterCycle/setup-singularity@v7
+        with:
+           singularity-version: 3.8.3
+        
+      - name: Singularity build in detached mode
+        run: singularity build --fakeroot -d singularity_image_def.sif `pwd`/singularity/singularity-reciepe.def
+        
+      - name: copying necessary files
+        run: |
+          mv singularity_image_def.sif `pwd`/tutorials/CFD/01POD/
+          mv `pwd`/singularity/Of.sh `pwd`/tutorials/CFD/01POD/
+        
+      - name: Run singulairty in batch mode
+        run: |
+          cd `pwd`/tutorials/CFD/01POD/
+          singularity exec singularity_image_def.sif /bin/bash Of.sh
+        
+        
+      
+      

--- a/.github/workflows/Singularity_from_docker.yml
+++ b/.github/workflows/Singularity_from_docker.yml
@@ -1,0 +1,36 @@
+name: Singularity_from_Docker_Image
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  singularity-from-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+     
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - uses: eWaterCycle/setup-singularity@v7
+        with:
+           singularity-version: 3.8.3
+        
+      - name: Singularity build
+        run: singularity build singularity_image.sif docker://ithacafv/ithacafv:manifest-latest
+        
+      - name: copying necessary files
+        run: |
+          mv singularity_image.sif `pwd`/tutorials/CFD/01POD/
+          mv `pwd`/singularity/Of.sh `pwd`/tutorials/CFD/01POD/
+        
+      - name: Singulairty in batch mode
+        run: |
+          cd `pwd`/tutorials/CFD/01POD/
+          singularity exec singularity_image.sif /bin/bash Of.sh
+        
+        
+      
+      

--- a/README.md
+++ b/README.md
@@ -101,7 +101,67 @@ Once the image is downloaded, you can start the container and mount the $HOME di
 docker run -ti --rm -v "${HOME}:/home/ithacafv/${USER}" ithacafv/ithacafv:manifest-latest
 ```
 
-### 4. [Tutorials](https://mathlab.github.io/ITHACA-FV//examples.html)
+### 4. Singularity
+
+
+Create a local directory (which you own), followed by using the variables, `SINGULARITY_TMPDIR` and `SINGULARITY_CACHEDIR` for temporary and cache directory during built proccess. This step is highly recommended if you do NOT have `root` access, as singularity uses a temporary directory to build the squashfs filesystem, and this temp space needs to be large enough to hold the entire resulting Singularity image.
+
+```
+export SINGULARITY_TMPDIR=$HOME/mycontainter
+```
+and 
+
+```
+export SINGULARITY_CACHEDIR=$HOME/mycontainter
+```
+
+Buidling singularity image file `.sif` from the docker image, which is build and stored in `$HOME/mycontainter`, The below image used is based **OpenFOAM-v2106**, and where you can find a compiled version of the master branch of **ITHACA-FV**.
+
+```
+singularity build ithacafv.sif docker://ithacafv/ithacafv:manifest-latest
+```
+
+To view / list all the images/cache, 
+
+```
+singularity cache list -v
+```
+
+To run the singulairty image interactively, use `shell` from your working directory. This mounts your working directory to the container. Activate the the OpenFOAM environment after`shell`, using `source /usr/lib/openfoam/openfoam2106/etc/bashrc` (or, `source /etc/bash.bashrc`)
+
+```
+singularity shell $HOME/mycontainter/ithacafv.sif
+```
+
+To build singularity images from scratch use defination files, `singularity-reciepe.def` provided in singularity directory. This require `sudo` prilvildges. Recommened to build in detached mode, by passing the flag `-d`.
+
+```
+sudo singularity build -d ithacafv.sif singularity/singularity-reciepe.def
+```
+
+Additionally, `--fakeroot` can be passed if you do NOT have root access for the build.
+
+```
+singularity build --fakeroot ithacafv.sif singularity/singularity-reciepe.def
+```
+
+Running singualrity in batch mode, you can add the following in your the batch script, 
+
+```
+singularity exec <image>.sif <command>
+```
+
+For example, running the any tutorial, add the following in the batch script,
+
+```
+singularity exec ithacafv.sif /bin/bash -c Of.sh
+``` 
+
+the shell script `Of.sh` is provided within the singularity directory. A sample batch scipt is also proived. Please note, over slurm machine, mpi binds without passing any flags.
+
+
+
+### 5. [Tutorials](https://mathlab.github.io/ITHACA-FV//examples.html)
 Several tutorials are provided in the [**tutorials** subfolder](./tutorials).
 *   [**CFD/Tutorial 1**](https://github.com/mathLab/ITHACA-FV/tree/master/tutorials/CFD/01POD): In this tutorial it is shown how to perform POD on an already run standard **OpenFOAM** case.
 *   [**CFD/Tutorial 2**](https://github.com/mathLab/ITHACA-FV/tree/master/tutorials/CFD/02thermalBlock): In this tutorial the development of a parametrized POD-Galerkin ROM for a steady heat transfer problem is implemented. The parametrization is on the diffusivity constant. The OpenFOAM full order problem is based on **laplacianFoam**.
@@ -115,12 +175,12 @@ Several tutorials are provided in the [**tutorials** subfolder](./tutorials).
 *   [**CFD/Tutorial 9**](https://mathlab.github.io/ITHACA-FV/09DEIM_ROM_8C-example.html): In this tutorial we propose an example concerning the usage of the Discrete Empirical Interpolation Methods for model reduction purposes. The non-linearity is in the forcing term of a heat transfer problem. The OpenFOAM full order problem is based on **laplacianFoam**.
 
 
-### 5. Authors and contributors
+### 6. Authors and contributors
 **ITHACA-FV** is currently developed and mantained at [SISSA mathLab](http://mathlab.sissa.it/) by [Dr. Giovanni Stabile](mailto:gstabile@sissa.it) under the supervision of [Prof. Gianluigi Rozza](mailto:gianluigi.rozza@sissa.it)
 
 Contact us by email for further information or questions about **ITHACA-FV**, or open an ''Issue'' on this website. **ITHACA-FV** is at an early development stage, so contributions improving either the code or the documentation are welcome, both as patches or merge requests on this website. If you are willing to contribute please follow the [developer instructions](https://github.com/mathLab/ITHACA-FV/tree/master/src).
 
-### 6. How to cite
+### 7. How to cite
 Most of the theoretical aspects behind **ITHACA-FV** are deeply explained in [<b> Stabile2017CAIM </b>](https://arxiv.org/pdf/1701.03424.pdf) and [<b> Stabile2017CAF </b>](https://arxiv.org/pdf/1710.11580.pdf).
 For this reason, if you use this software, please consider citing the mentioned works, reported in the following bibtex entries:
 ```
@@ -148,5 +208,5 @@ Doi                      = {10.1016/j.compfluid.2018.01.035}}
 and cite the [ITHACA-FV website](http://mathlab.sissa.it/ITHACA-FV).
 
 
-### 7. License
+### 8. License
 **ITHACA-FV** is freely available under the GNU LGPL, version 3.

--- a/dockerfiles/amd64/Dockerfile
+++ b/dockerfiles/amd64/Dockerfile
@@ -2,8 +2,10 @@ FROM  opencfd/openfoam2106-dev
 LABEL maintainer="moaadkhamlich@gmail.com"
 
 
-# add and enable the default user
+# add enviromental variables and enable the default user
 ARG USER=ithacafv
+ARG of_var="source /usr/lib/openfoam/openfoam2106/etc/bashrc"
+ARG ithaca_var="source /usr/lib/ITHACA-FV/etc/bashrc"
 ENV USER $USER
 
 # Create the user
@@ -36,11 +38,23 @@ RUN chown -R $USER:$USER openfoam ITHACA-FV
 RUN chown -R $USER:$USER /home/$USER
 USER $USER
 
-RUN /bin/bash -c "source openfoam/openfoam2106/etc/bashrc && \
-    cd ITHACA-FV && git submodule update --init && source etc/bashrc && \
-    ./Allwmake -au -j 4";
+RUN /bin/bash -c "source /usr/lib/openfoam/openfoam2106/etc/bashrc && \
+    cd ITHACA-FV && git submodule update --init && source /etc/bash.bashrc && \
+    ./Allwmake -tau -j 4";
+
+USER root
+RUN 	cp -r /home/ithacafv/OpenFOAM/ithacafv-v2106/platforms/linux64GccDPInt32Opt/bin/* /bin/
+RUN 	cp -r /home/ithacafv/OpenFOAM/ithacafv-v2106/platforms/linux64GccDPInt32Opt/lib/* /lib/
+
+#Update bashrc 
+RUN  echo $of_var >> /etc/bash.bashrc
+RUN  echo $ithaca_var >> /etc/bash.bashrc
+
+#Source bashrc
+USER $USER
+RUN /bin/bash -c "source /etc/bash.bashrc"
 
 USER $USER
 WORKDIR $HOME
-COPY .bashrc $HOME/.bashrc
 ENTRYPOINT ["/bin/bash"]
+

--- a/dockerfiles/arm64/Dockerfile
+++ b/dockerfiles/arm64/Dockerfile
@@ -11,8 +11,12 @@ RUN apt-get update \
 		software-properties-common ;\
 		rm -rf /var/lib/apt/lists/*
 
-# add and enable the default user
+# add enviromental variables
 ARG USER=ithacafv
+ARG of_var="source /usr/lib/openfoam/openfoam2106/etc/bashrc"
+ARG ithaca_var="source /usr/lib/ITHACA-FV/etc/bashrc"
+
+# add and enable the default user
 RUN adduser --disabled-password --gecos '' $USER
 RUN adduser $USER sudo; echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
@@ -25,11 +29,22 @@ USER $USER
 ENV HOME /home/$USER
 ENV USER $USER
 
-RUN /bin/bash -c "source OpenFOAM-v2106/etc/bashrc && \
-    cd ITHACA-FV && git submodule update --init && source etc/bashrc && \
-    ./Allwmake -au -j 4";
+RUN /bin/bash -c "source /usr/lib/openfoam/openfoam2106/etc/bashrc && \
+    cd ITHACA-FV && git submodule update --init && source /etc/bash.bashrc && \
+    ./Allwmake -tau -j 4";
+
+USER root
+RUN 	cp -r /home/ithacafv/OpenFOAM/ithacafv-v2106/platforms/linux64GccDPInt32Opt/bin/* /bin/
+RUN 	cp -r /home/ithacafv/OpenFOAM/ithacafv-v2106/platforms/linux64GccDPInt32Opt/lib/* /lib/
 
 
+#Update bashrc 
+RUN	echo $of_var >> /etc/bash.bashrc
+RUN	echo $ithaca_var >> /etc/bash.bashrc
+
+#Source bashrc
+RUN /bin/bash -c "source /etc/bash.bashrc"
+
+USER $USER
 WORKDIR $HOME
-COPY .bashrc $HOME/.bashrc
 ENTRYPOINT ["/bin/bash"]

--- a/singularity/Of.sh
+++ b/singularity/Of.sh
@@ -1,0 +1,9 @@
+##sourcing the correct bashrc is important
+##bashrc for OpenFOAM 
+source /usr/lib/openfoam/openfoam2106/etc/bashrc
+## bashrc for OpenFOAM and Ithaca-FV
+##source /etc/bash.bashrc
+
+##./Allrun
+icoFoam ##-paralell
+perform_POD

--- a/singularity/batch_script
+++ b/singularity/batch_script
@@ -1,0 +1,33 @@
+#!/bin/bash
+#SBATCH -n 4        # Number of cores
+#SBATCH -t 0-00:45  # Runtime in D-HH:MM
+#SBATCH --job-name=singularity
+#SBATCH -p regular1
+
+
+#load singularity and MPI modules
+module load singularity/3.4.1
+module load intel/2021.2
+module load openmpi3
+
+
+echo "Starting singularity on host $HOSTNAME"
+
+#this binds mpi, so we do not need to 
+#srun -n 4 singularity exec ithacafv.sif /bin/bash Of.sh
+
+#without MPI
+singularity exec ithicafv.sif /bin/bash Of.sh
+
+#Other valid 
+
+#mpi run not recomeneded
+#mpirun -n 4 singularity exec ithacafv.sif /bin/bash Of.sh
+
+#mpiexec -n 4 singularity exec ithacafv.sif /bin/bash Of.sh
+
+#singularity exec ithicafv.sif /bin/bash Of.sh
+
+echo "Completed singularity on host $HOSTNAME"
+
+

--- a/singularity/singularity-reciepe.def
+++ b/singularity/singularity-reciepe.def
@@ -1,0 +1,104 @@
+
+Bootstrap: docker
+From: opencfd/openfoam2106-dev
+Stage: build
+
+
+%environment
+	of_var="source /usr/lib/openfoam/openfoam2106/etc/bashrc"
+	ithaca_var="source /usr/lib/ITHACA-FV/etc/bashrc"
+	export of_var ithaca_var
+
+%post
+	
+	#Define variables
+	USER="ithacafv"
+	of_var="source /usr/lib/openfoam/openfoam2106/etc/bashrc"
+	ithaca_var="source /usr/lib/ITHACA-FV/etc/bashrc"
+	
+	# Create the user
+	cd ~
+	adduser --disabled-password --gecos '' $USER && \
+    	adduser $USER sudo; echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    	usermod -a -G $USER $USER && \
+    	userdel sudofoam && \
+    	usermod -u 1000 ithacafv  && \
+    	groupmod -g 1000 ithacafv
+
+	cd /home/$USER
+	
+	chown -R $USER:$USER /home/$USER
+	chown -R $USER:$USER /home/openfoam && rm -r /home/openfoam && \
+    	chown -R $USER:$USER /home/sudofoam && rm -r /home/sudofoam
+	
+	#install necessary packages
+	cd ~ 
+	
+	sudo apt-get update
+	sudo apt-get install git -y
+        sudo apt-get install vim -y
+        
+        #get the lastest version of ITHACA-FV       
+        cd /usr/lib/
+	
+	git clone https://github.com/mathLab/ITHACA-FV.git
+	
+	#install ITHACA-FV 
+	/bin/bash -c "source /usr/lib/openfoam/openfoam2106/etc/bashrc && \
+    	cd ITHACA-FV && git submodule update --init && source /etc/bash.bashrc && \
+    	./Allwmake -tau -j 4 && \
+    	cd ~ && \
+    	cp -r /root/OpenFOAM/-v2106/platforms/linux64GccDPInt32Opt/bin/* /bin/ &&\
+    	cp -r /root/OpenFOAM/-v2106/platforms/linux64GccDPInt32Opt/lib/* /lib/"
+    	
+    	#Update bashrc 
+	echo $of_var >> /etc/bash.bashrc
+	echo $ithaca_var >> /etc/bash.bashrc
+	
+	#source bashrc
+	/bin/bash -c "source /etc/bash.bashrc"
+
+	
+%runscript
+	/bin/bash -c "source /etc/bash.bashrc"
+	echo "singularity container for ithacafv with openfoam"
+	echo "to activate the openfoam environment use"
+	echo "source /usr/lib/openfoam/openfoam2106/etc/bashrc"
+	echo "to activate the openfoam and ithacafv environment use"
+	echo "source /etc/bash.bashrc"
+
+
+%labels
+	Author Pavan Pranjivan Mehta, Email : pavan_pranjivan_mehta@alumni.brown.edu
+	Version v0.1
+
+%help
+    	This is a singularity container for ITHACA-FV. 
+    	
+    	Please note the openFoam version is as per the docker image : "opencfd/openfoam2106-dev". 
+    	
+    	Change the docker image in the ".def" file for a different openFoam version.
+    	
+    	Source code : https://github.com/mathLab/ITHACA-FV.git 
+    	
+    	1. To run intertactively, use "run" or "shell", 
+    		singularity shell <image>
+    	
+    	2. To run in batch mode, use "exec" / "run"
+	    	singularity exec <image> <command>
+	    	
+	3. MPI over slurm binds itself, with "exec"
+		mpirun -n $n singularity exec <image> <command>
+		
+		Other valid statements,
+		
+		srun -n $n singularity exec <image> <command>
+		
+		mpiexec -n $n singularity exec <image> <command>
+	
+	4. Using MPI over non-slurm machine, you will need to pass "--bind" with path to MPI installation directory.
+	
+	
+	Author : Pavan Pranjivan Mehta
+	Email : pavan.mehta@sissa.it 
+		    	


### PR DESCRIPTION
Files modified :: /singularity/ , /dockerfiles , * * Readme.md** and workflows

1. Singularity implemented using both from definition file and from docker images.

2. Docker files updated to integrate with singularity (also images used for development docker://mehtapavan/ithacafv-manifest:6.2). This version is generated from the docker-files modified here.

3. Batch mode with singularity tested over cluster (CFD/01POD) (see the batch_script with singularity directory and ReadMe)

4. GitHub actions for testing singularity via def file and docker image.

PS : Replace the docker image to official ithaca-FV docker image in "Singularity_from_docker.yml". I can send another pull-request for it; as merging this should automatically create docker-images, only then Github action should be updated