### PR TITLE
Pull request: Add functions into "ITHACAstream" to read the converged fields in parallel.

### DIFF
--- a/src/ITHACA_CORE/ITHACAstream/ITHACAstream.C
+++ b/src/ITHACA_CORE/ITHACAstream/ITHACAstream.C
@@ -691,6 +691,77 @@ void readConvergedFields(
     }
 }
 
+template<class Type, template<class> class PatchField, class GeoMesh>
+void read_last_fields(
+    PtrList<GeometricField<Type, PatchField, GeoMesh>>& Lfield,
+    GeometricField<Type, PatchField, GeoMesh>& field,
+    fileName casename)
+{
+    if (!Pstream::parRun())
+    {
+        Info << "######### Reading the Data for " << field.name() << " #########" <<
+             endl;
+        fileName rootpath(".");
+        Foam::Time runTime2(Foam::Time::controlDictName, rootpath, casename);
+        int last_s (runTime2.times().size());
+
+        GeometricField<Type, PatchField, GeoMesh> tmp_field(
+            IOobject
+            (
+                field.name(),
+                casename + runTime2.times()[last_s-1].name(),
+                field.mesh(),
+                IOobject::MUST_READ
+            ),
+            field.mesh()
+        );
+        Lfield.append(tmp_field.clone());
+
+        std::cout << std::endl;
+    }
+    else
+    {
+        Info << "######### Reading the Data for " << field.name() << " #########" <<
+             endl;
+        word timename(field.mesh().time().rootPath() + "/" +
+                      field.mesh().time().caseName() );
+        timename = timename.substr(0, timename.find_last_of("\\/"));
+        timename = timename + "/" + casename + "processor" + name(Pstream::myProcNo());
+        int last_s = numberOfFiles(casename,
+                                   "processor" + name(Pstream::myProcNo()) + "/");
+
+        GeometricField<Type, PatchField, GeoMesh> tmp_field(
+            IOobject
+            (
+                field.name(),
+                timename + "/" + name(last_s-1),
+                field.mesh(),
+                IOobject::MUST_READ
+            ),
+            field.mesh()
+        );
+        Lfield.append(tmp_field.clone());
+
+        Info << endl;
+    }
+}
+
+template<class Type, template<class> class PatchField, class GeoMesh>
+void readLastFields(
+    PtrList<GeometricField<Type, PatchField, GeoMesh>>& Lfield,
+    GeometricField<Type, PatchField, GeoMesh>& field, fileName casename)
+{
+    int par = 1;
+    M_Assert(ITHACAutilities::check_folder(casename + name(par)) != 0,
+             "No parameter dependent solutions stored into Offline folder");
+
+    while (ITHACAutilities::check_folder(casename + name(par)))
+    {
+        read_last_fields(Lfield, field, casename + name(par) + "/");
+        par++;
+    } 
+}
+
 int numberOfFiles(word folder, word MatrixName, word ext)
 {
     int number_of_files = 0;
@@ -951,6 +1022,27 @@ template void readConvergedFields(PtrList<surfaceScalarField>&
                                   Lfield, surfaceScalarField& field, fileName casename);
 template void readConvergedFields(PtrList<surfaceVectorField>&
                                   Lfield, surfaceVectorField& field, fileName casename);
+
+template void read_last_fields(PtrList<volScalarField>& Lfield,
+                          volScalarField& field, fileName casename);
+template void read_last_fields(PtrList<volVectorField>& Lfield,
+                          volVectorField& field, fileName casename);
+template void read_last_fields(PtrList<volTensorField>& Lfield,
+                          volTensorField& field, fileName casename);
+template void read_last_fields(PtrList<surfaceScalarField>& Lfield,
+                          surfaceScalarField& field, fileName casename);
+template void read_last_fields(PtrList<surfaceVectorField>& Lfield,
+                          surfaceVectorField& field, fileName casename);
+template void readLastFields(PtrList<volScalarField>& Lfield,
+                               volScalarField& field, fileName casename);
+template void readLastFields(PtrList<volVectorField>& Lfield,
+                               volVectorField& field, fileName casename);
+template void readLastFields(PtrList<volTensorField>& Lfield,
+                               volTensorField& field, fileName casename);
+template void readLastFields(PtrList<surfaceScalarField>&
+                               Lfield, surfaceScalarField& field, fileName casename);
+template void readLastFields(PtrList<surfaceVectorField>&
+                               Lfield, surfaceVectorField& field, fileName casename);
 
 template<typename T>
 void exportList(T& list, word folder, word filename)

--- a/src/ITHACA_CORE/ITHACAstream/ITHACAstream.H
+++ b/src/ITHACA_CORE/ITHACAstream/ITHACAstream.H
@@ -229,6 +229,44 @@ void readConvergedFields(
     GeometricField<Type, PatchField, GeoMesh>& field,
     fileName casename);
 
+//----------------------------------------------------------------------
+/// Function to read a list of fields from the name of the field including only the last snapshot
+///
+/// @param[in]  Lfield      a PtrList of OpenFOAM fields where you want
+///                         to store the field.
+/// @param[in]  field       The field used as template to read other
+///                         fields.
+/// @param[in]  casename    The folder where the field is stored.
+
+/// @tparam     Type        vector or scalar.
+/// @tparam     PatchField  fvPatchField or fvsPatchField.
+/// @tparam     GeoMesh     volMesh or surfaceMesh.
+///
+template<class Type, template<class> class PatchField, class GeoMesh>
+void read_last_fields(PtrList<GeometricField<Type, PatchField, GeoMesh>>&
+                 Lfield,
+                 GeometricField<Type, PatchField, GeoMesh>& field,
+                 fileName casename); 
+
+//----------------------------------------------------------------------
+/// Funtion to read a list of volVectorField from name of the field including only the last snapshots
+///
+/// @param[in]  Lfield      a PtrList of OpenFOAM fields where you want
+///                         to store the field.
+/// @param[in]  field       The field used as template to read other
+///                         fields.
+/// @param[in]  casename    The folder where the field is stored.
+///
+/// @tparam     Type        vector or scalar.
+/// @tparam     PatchField  fvPatchField or fvsPatchField.
+/// @tparam     GeoMesh     volMesh or surfaceMesh.
+///
+template<class Type, template<class> class PatchField, class GeoMesh>
+void readLastFields(PtrList<GeometricField<Type, PatchField, GeoMesh>>&
+                      Lfield,
+                      GeometricField<Type, PatchField, GeoMesh>& field,
+                      fileName casename);
+
 //--------------------------------------------------------------------------
 /// Function to export a scalar of vector field
 ///

--- a/src/ITHACA_CORE/ITHACAstream/ITHACAstream.H
+++ b/src/ITHACA_CORE/ITHACAstream/ITHACAstream.H
@@ -245,8 +245,8 @@ void readConvergedFields(
 template<class Type, template<class> class PatchField, class GeoMesh>
 void read_last_fields(PtrList<GeometricField<Type, PatchField, GeoMesh>>&
                  Lfield,
-                 GeometricField<Type, PatchField, GeoMesh>& field,
-                 fileName casename); 
+                 const GeometricField<Type, PatchField, GeoMesh>& field,
+                 const fileName casename); 
 
 //----------------------------------------------------------------------
 /// Funtion to read a list of volVectorField from name of the field including only the last snapshots
@@ -264,8 +264,8 @@ void read_last_fields(PtrList<GeometricField<Type, PatchField, GeoMesh>>&
 template<class Type, template<class> class PatchField, class GeoMesh>
 void readLastFields(PtrList<GeometricField<Type, PatchField, GeoMesh>>&
                       Lfield,
-                      GeometricField<Type, PatchField, GeoMesh>& field,
-                      fileName casename);
+                      const GeometricField<Type, PatchField, GeoMesh>& field,
+                      const fileName casename);
 
 //--------------------------------------------------------------------------
 /// Function to export a scalar of vector field

--- a/src/ITHACA_FOMPROBLEMS/SteadyNSSimple/SteadyNSSimple.C
+++ b/src/ITHACA_FOMPROBLEMS/SteadyNSSimple/SteadyNSSimple.C
@@ -88,7 +88,8 @@ void SteadyNSSimple::getTurbRBF(label NNutModes)
             ITHACAstream::ReadDenseMatrix(weights, "./ITHACAoutput/weights/", weightName);
             rbfSplines[i] = new SPLINTER::RBFSpline(*samples[i],
                                                     SPLINTER::RadialBasisFunctionType::GAUSSIAN, weights);
-            std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+            // std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+            Info<< "Constructing RadialBasisFunction for mode " << i + 1 << endl;
         }
         else
         {
@@ -104,7 +105,8 @@ void SteadyNSSimple::getTurbRBF(label NNutModes)
                                                     SPLINTER::RadialBasisFunctionType::GAUSSIAN);
             ITHACAstream::SaveDenseMatrix(rbfSplines[i]->weights,
                                           "./ITHACAoutput/weights/", weightName);
-            std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+            // std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+            Info<< "Constructing RadialBasisFunction for mode " << i + 1 << endl;
         }
     }
 }

--- a/tutorials/CFD/18simpleTurbNS/18simpleTurbNS.C
+++ b/tutorials/CFD/18simpleTurbNS/18simpleTurbNS.C
@@ -66,7 +66,7 @@ class tutorial18 : public SteadyNSSimple
                 ITHACAstream::readMiddleFields(Ufield, U, "./ITHACAoutput/Offline/");
                 ITHACAstream::readMiddleFields(Pfield, p, "./ITHACAoutput/Offline/");
                 auto nut = _mesh().lookupObject<volScalarField>("nut");
-                ITHACAstream::readConvergedFields(nutFields, nut, "./ITHACAoutput/Offline/");
+                ITHACAstream::readLastFields(nutFields, nut, "./ITHACAoutput/Offline/");
                 mu_samples =
                     ITHACAstream::readMatrix("./ITHACAoutput/Offline/mu_samples_mat.txt");
             }


### PR DESCRIPTION
1-Add two functions, _read_last_fields_ and _readLastFields_, to the **ITHACAstream**. The two functions allow parallel reading of the converged fields in the subfolders. 
2-The solver, _18simpleTurbNS_, is also modified.
3-Declear as _const_ for those immutable variables in the _read_last_fields_ function.
4-Use pointers to improve the code's efficiency, following Dr. Mark Olesen's suggestions.
5-Add `#if defined(OFVER) && (OFVER >= 2212)_` to activate _emplace_back_ function for the new OF version.
6-Use `Info` instead of `std::cout` in the `getTurbRBF` function to reduce repeating print.
