### PR TITLE
PR: add new cached procedures to compute the tensor, which avoid redundent computation in the for loops.

### DIFF
--- a/src/ITHACA_FOMPROBLEMS/SteadyNSTurb/SteadyNSTurb.C
+++ b/src/ITHACA_FOMPROBLEMS/SteadyNSTurb/SteadyNSTurb.C
@@ -201,9 +201,40 @@ Eigen::Tensor<double, 3> SteadyNSTurb::turbulenceTensor1(label NUmodes,
     return ct1Tensor;
 }
 
+Eigen::Tensor<double, 3> SteadyNSTurb::turbulenceTensor1_cache(label NUmodes,
+        label NSUPmodes, label nNutModes)
+{
+    label cSize = NUmodes + NSUPmodes + liftfield.size();
+    Eigen::Tensor<double, 3> ct1Tensor(cSize, nNutModes, cSize);
 
+    for (label j = 0; j < nNutModes; ++j)
+    {
+        // Cache only one row (j fixed)
+        List<tmp<volVectorField>> lapRow(cSize);
+        for (label k = 0; k < cSize; ++k)
+        {
+            lapRow[k] = fvc::laplacian(nutModes[j], L_U_SUPmodes[k]);
+        }
 
+        for (label i = 0; i < cSize; ++i)
+        {
+            for (label k = 0; k < cSize; ++k)
+            {
+                const volVectorField& lapField = lapRow[k]();
+                ct1Tensor(i, j, k) = fvc::domainIntegrate(L_U_SUPmodes[i] & lapField).value();
+            }
+        }
+    }
 
+    // Export the tensor
+    if (Pstream::master())
+    {
+        ITHACAstream::SaveDenseTensor(ct1Tensor, "./ITHACAoutput/Matrices/",
+                                      "ct1_" + name(liftfield.size()) + "_" + name(NUmodes) + "_" + name(
+                                          NSUPmodes) + "_" + name(nNutModes) + "_t");
+    }
+    return ct1Tensor;
+}
 
 List < Eigen::MatrixXd > SteadyNSTurb::turbulenceTerm2(label NUmodes,
         label NSUPmodes, label nNutModes)
@@ -268,6 +299,41 @@ Eigen::Tensor<double, 3> SteadyNSTurb::turbulenceTensor2(label NUmodes,
     return ct2Tensor;
 }
 
+Eigen::Tensor<double, 3> SteadyNSTurb::turbulenceTensor2_cache(label NUmodes,
+        label NSUPmodes, label nNutModes)
+{
+    label cSize = NUmodes + NSUPmodes + liftfield.size();
+    Eigen::Tensor<double, 3> ct2Tensor(cSize, nNutModes, cSize);
+
+    for (label j = 0; j < nNutModes; ++j)
+    {
+        // Cache only one j-row
+        List<tmp<volVectorField>> divRow(cSize);
+        for (label k = 0; k < cSize; ++k)
+        {
+            divRow[k] = fvc::div(nutModes[j] * dev((fvc::grad(L_U_SUPmodes[k]))().T()));
+        }
+
+        for (label i = 0; i < cSize; ++i)
+        {
+            for (label k = 0; k < cSize; ++k)
+            {
+                const volVectorField& divRowField = divRow[k]();
+                ct2Tensor(i, j, k) = fvc::domainIntegrate(L_U_SUPmodes[i] & divRowField).value();
+            }
+        }
+    }
+
+    // Export the tensor
+    if (Pstream::master())
+    {
+        ITHACAstream::SaveDenseTensor(ct2Tensor, "./ITHACAoutput/Matrices/",
+                                      "ct2_" + name(liftfield.size()) + "_" + name(NUmodes) + "_" + name(
+                                          NSUPmodes) + "_" + name(nNutModes) + "_t");
+    }
+    return ct2Tensor;
+}
+
 Eigen::Tensor<double, 3> SteadyNSTurb::turbulencePPETensor1(label NUmodes,
         label NSUPmodes, label NPmodes, label nNutModes)
 {
@@ -300,6 +366,48 @@ Eigen::Tensor<double, 3> SteadyNSTurb::turbulencePPETensor1(label NUmodes,
     return ct1PPETensor;
 }
 
+Eigen::Tensor<double, 3> SteadyNSTurb::turbulencePPETensor1_cache(label NUmodes,
+        label NSUPmodes, label NPmodes, label nNutModes)
+{
+    label cSize = NUmodes + NSUPmodes + liftfield.size();
+    Eigen::Tensor<double, 3> ct1PPETensor(NPmodes, nNutModes, cSize);
+
+    List<tmp<volVectorField>> PmodesGrad(NPmodes);
+    for (label i = 0; i < NPmodes; ++i)
+    {
+        PmodesGrad[i] = fvc::grad(Pmodes[i]);
+    }
+
+    for (label j = 0; j < nNutModes; ++j)
+    {
+        // Cache one row (j fixed)
+        List<tmp<volVectorField>> lapRow(cSize);
+        for (label k = 0; k < cSize; ++k)
+        {
+            lapRow[k] = fvc::laplacian(nutModes[j], L_U_SUPmodes[k]);
+        }
+
+        for (label i = 0; i < NPmodes; ++i)
+        {
+            const volVectorField& gradPi = PmodesGrad[i]();
+            for (label k = 0; k < cSize; ++k)
+            {
+                const volVectorField& lapRowField = lapRow[k]();
+                ct1PPETensor(i, j, k) = fvc::domainIntegrate(gradPi & lapRowField).value();
+            }
+        }
+    }
+
+    // Export the tensor
+    if (Pstream::master())
+    {
+        ITHACAstream::SaveDenseTensor(ct1PPETensor, "./ITHACAoutput/Matrices/",
+                                      "ct1PPE_" + name(liftfield.size()) + "_" + name(NUmodes) + "_" + name(
+                                          NSUPmodes) + "_" + name(NPmodes) + "_" + name(nNutModes) + "_t");
+    }
+    return ct1PPETensor;
+}
+
 Eigen::Tensor<double, 3> SteadyNSTurb::turbulencePPETensor2(label NUmodes,
         label NSUPmodes, label NPmodes, label nNutModes)
 {
@@ -328,6 +436,48 @@ Eigen::Tensor<double, 3> SteadyNSTurb::turbulencePPETensor2(label NUmodes,
     ITHACAstream::SaveDenseTensor(ct2PPETensor, "./ITHACAoutput/Matrices/",
                                   "ct2PPE_" + name(liftfield.size()) + "_" + name(NUmodes) + "_" + name(
                                       NSUPmodes) + "_" + name(NPmodes) + "_" + name(nNutModes) + "_t");
+    return ct2PPETensor;
+}
+
+Eigen::Tensor<double, 3> SteadyNSTurb::turbulencePPETensor2_cache(label NUmodes,
+        label NSUPmodes, label NPmodes, label nNutModes)
+{
+    label cSize = NUmodes + NSUPmodes + liftfield.size();
+    Eigen::Tensor<double, 3> ct2PPETensor(NPmodes, nNutModes, cSize);
+
+    List<tmp<volVectorField>> PmodesGrad(NPmodes);
+    for (label i = 0; i < NPmodes; ++i)
+    {
+        PmodesGrad[i] = fvc::grad(Pmodes[i]);
+    }
+
+    for (label j = 0; j < nNutModes; ++j)
+    {
+        // Cache one row of div fields for this nutMode[j]
+        List<tmp<volVectorField>> divLow(cSize);
+        for (label k = 0; k < cSize; ++k)
+        {
+            divLow[k] = fvc::div(nutModes[j] * dev2((fvc::grad(L_U_SUPmodes[k]))().T()));
+        }
+
+        for (label i = 0; i < NPmodes; ++i)
+        {
+            const volVectorField& gradPi = PmodesGrad[i]();
+            for (label k = 0; k < cSize; ++k)
+            {
+                const volVectorField& divLowField = divLow[k]();
+                ct2PPETensor(i, j, k) = fvc::domainIntegrate(gradPi & divLowField).value();
+            }
+        }
+    }
+
+    // Export the tensor
+    if (Pstream::master())
+    {
+        ITHACAstream::SaveDenseTensor(ct2PPETensor, "./ITHACAoutput/Matrices/",
+                                      "ct2PPE_" + name(liftfield.size()) + "_" + name(NUmodes) + "_" + name(
+                                          NSUPmodes) + "_" + name(NPmodes) + "_" + name(nNutModes) + "_t");
+    }
     return ct2PPETensor;
 }
 

--- a/src/ITHACA_FOMPROBLEMS/SteadyNSTurb/SteadyNSTurb.H
+++ b/src/ITHACA_FOMPROBLEMS/SteadyNSTurb/SteadyNSTurb.H
@@ -195,6 +195,18 @@ class SteadyNSTurb: public steadyNS
         ///
         Eigen::Tensor<double, 3 > turbulenceTensor1(label NUmodes,
                 label NSUPmodes, label nNutModes);
+        
+        //--------------------------------------------------------------------------
+        /// @brief      ct1 tensor for the turbulence treatement using the cached procedure
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        /// @param[in]  nNutModes  The number of eddy viscosity modes.
+        ///
+        /// @return     ct1 tensor for the turbulence treatement
+        ///
+        Eigen::Tensor<double, 3 > turbulenceTensor1_cache(label NUmodes,
+                label NSUPmodes, label nNutModes);
 
         //--------------------------------------------------------------------------
         /// @brief      Method to compute one of the turbulence eddy viscosity tensors
@@ -221,6 +233,18 @@ class SteadyNSTurb: public steadyNS
                 label NSUPmodes, label nNutModes);
 
         //--------------------------------------------------------------------------
+        /// @brief      Method to compute one of the turbulence eddy viscosity tensors using the cached procedure
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        /// @param[in]  nNutModes  The number of eddy viscosity modes.
+        ///
+        /// @return     ct2 tensor for the turbulence treatement
+        ///
+        Eigen::Tensor<double, 3 > turbulenceTensor2_cache(label NUmodes,
+                label NSUPmodes, label nNutModes);
+
+        //--------------------------------------------------------------------------
         /// @brief      ct1PPE added tensor for the turbulence treatement in the PPE method
         ///
         /// @param[in]  NUmodes    The number of velocity modes.
@@ -231,6 +255,19 @@ class SteadyNSTurb: public steadyNS
         /// @return     ct1PPE tensor for the turbulence treatement in the PPE method
         ///
         Eigen::Tensor<double, 3 > turbulencePPETensor1(label NUmodes,
+                label NSUPmodes, label NPmodes, label nNutModes);
+
+        //--------------------------------------------------------------------------
+        /// @brief      ct1PPE added tensor for the turbulence treatement in the PPE method using the cached procedure
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        /// @param[in]  NPmodes    The number of pressure modes.
+        /// @param[in]  nNutModes  The number of eddy viscosity modes.
+        ///
+        /// @return     ct1PPE tensor for the turbulence treatement in the PPE method
+        ///
+        Eigen::Tensor<double, 3 > turbulencePPETensor1_cache(label NUmodes,
                 label NSUPmodes, label NPmodes, label nNutModes);
 
         //--------------------------------------------------------------------------
@@ -246,6 +283,18 @@ class SteadyNSTurb: public steadyNS
         Eigen::Tensor<double, 3 > turbulencePPETensor2(label NUmodes,
                 label NSUPmodes, label NPmodes, label nNutModes);
 
+        //--------------------------------------------------------------------------
+        /// @brief      ct2PPE added tensor for the turbulence treatement in the PPE method using the cached procedure
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NSUPmodes  The number of supremizer modes.
+        /// @param[in]  NPmodes    The number of pressure modes.
+        /// @param[in]  nNutModes  The number of eddy viscosity modes.
+        ///
+        /// @return     ct2PPE tensor for the turbulence treatement in the PPE method
+        ///
+        Eigen::Tensor<double, 3 > turbulencePPETensor2_cache(label NUmodes,
+                label NSUPmodes, label NPmodes, label nNutModes);
 };
 
 #endif

--- a/src/ITHACA_FOMPROBLEMS/steadyNS/steadyNS.H
+++ b/src/ITHACA_FOMPROBLEMS/steadyNS/steadyNS.H
@@ -474,6 +474,18 @@ class steadyNS: public reductionProblem
         /// @return     reduced third order tensor for the conv. term which is used for the PPE approach
         ///
         Eigen::Tensor<double, 3 > divMomentum(label NUmodes, label NPmodes);
+        
+        //--------------------------------------------------------------------------
+        /// Divergence of convective term (PPE approach) using the cached procedure
+        ///
+        /// @brief      Divergence of convective term (PPE approach)
+        ///
+        /// @param[in]  NUmodes    The number of velocity modes.
+        /// @param[in]  NPmodes    The number of pressure modes.
+        ///
+        /// @return     reduced third order tensor for the conv. term which is used for the PPE approach
+        ///
+        Eigen::Tensor<double, 3 > divMomentum_cache(label NUmodes, label NPmodes);
 
         //--------------------------------------------------------------------------
         /// Laplacian of pressure term (PPE approach)
@@ -788,6 +800,19 @@ class steadyNS: public reductionProblem
         /// @return     tensor_C
         ///
         Eigen::Tensor<double, 3 > convective_term_tens(label NUmodes,
+                label NPmodes,
+                label NSUPmodes);
+        
+        //--------------------------------------------------------------------------
+        /// @brief      Export convective term as a tensor using the cached procedure
+        ///
+        /// @param[in]  NUmodes    The N of velocity modes
+        /// @param[in]  NPmodes    The N of pressure modes
+        /// @param[in]  NSUPmodes  The N of supremizer modes
+        ///
+        /// @return     tensor_C
+        ///
+        Eigen::Tensor<double, 3 > convective_term_tens_cache(label NUmodes,
                 label NPmodes,
                 label NSUPmodes);
 


### PR DESCRIPTION
Dear Giovanni,

I created some new functions to compute tensors, which avoid some redundant computation in the for loop.

I have tested the performance of the modification, which will speed up the computation in an order close to **Csize**. The following is a description of my test case.

1. Problem: a modification based on **06POD_RBF**
2. Number of cells: 198000
3. Three tests are performed, and the results are listed in the table.

| Num modes | Original | Modified | Speedup ratio |
| --------- | --------     | -------- | ------------- |
| 3          | 19.58     | 4.62    | 4.24          |
| 5          | 93.33     | 14.71  | 6.34          |
| 10        | 691.85   | 60.6    | 11.42        |

A similar modification is applied to
1. divMomentum
2. turbulenceTensor1, turbulenceTensor2
3. turbulencePPETensor1, turbulencePPETensor2

The attached file contains a test case for comparing the Tensors generated by the new function with those from the original one, both in serial and parallel execution.
[06POD_RBF_cached_test.tar.gz](https://github.com/user-attachments/files/20525106/06POD_RBF_cached_test.tar.gz)

With best regards,
Shenhui

The explanation is listed below:

The computation of the [**convective_term_tens**](https://github.com/ITHACA-FV/ITHACA-FV/blob/ff7b59ff50d9078d5033c219f5c9615455f81f0a/src/ITHACA_FOMPROBLEMS/steadyNS/steadyNS.C#L997) contains three-layer loops. Therefore, the part  `fvc::div(linearInterpolate(L_U_SUPmodes[j]) & L_U_SUPmodes[j].mesh().Sf(), L_U_SUPmodes[k])` is computed **i** times, which is very costly.

```
for (label i = 0; i < Csize; i++)
{
    for (label j = 0; j < Csize; j++)
    {
        for (label k = 0; k < Csize; k++)
        {
            if (fluxMethod == "consistent")
            {
                C_tensor(i, j, k) = fvc::domainIntegrate(L_U_SUPmodes[i] & fvc::div(
                                        L_PHImodes[j],
                                        L_U_SUPmodes[k])).value();
            }
            else
            {
                C_tensor(i, j, k) = fvc::domainIntegrate(L_U_SUPmodes[i] & fvc::div(
                                        linearInterpolate(L_U_SUPmodes[j]) & L_U_SUPmodes[j].mesh().Sf(),
                                        L_U_SUPmodes[k])).value();
            }
        }
    }
```

The above code is OK for small-scale problems. But I am applying it to problems with several million cells, and the computation of the tensor becomes the bottleneck of the projection procedure.

I suggest computing the intermediate PrtList to accelerate the computation as follows:

```
PtrList< PtrList<volVectorField> > divCache(Csize);
for (label j = 0; j < Csize; ++j)
{
    PtrList<volVectorField> innerCache(Csize);

    for (label k = 0; k < Csize; ++k)
    {
        volVectorField* divFieldPtr = nullptr;

        if (fluxMethod == "consistent")
        {
            divFieldPtr = new volVectorField
            (
                fvc::div(L_PHImodes[j], L_U_SUPmodes[k])
            );
        }
        else
        {
            surfaceScalarField interp
            (
                linearInterpolate(L_U_SUPmodes[j]) & L_U_SUPmodes[j].mesh().Sf()
            );

            divFieldPtr = new volVectorField
            (
                fvc::div(interp, L_U_SUPmodes[k])
            );
        }
        innerCache.set(k, divFieldPtr);
    }
    divCache.set(j, new PtrList<volVectorField>(innerCache));
}

for (label i = 0; i < Csize; i++)
{
    for (label j = 0; j < Csize; j++)
    {
        for (label k = 0; k < Csize; k++)
        {
            C_tensor(i, j, k) = fvc::domainIntegrate(L_U_SUPmodes[i] & divCache[j][k]).value();
        }
    }
}
```