### PR TITLE
ENH: add Docker dependencies workflow and restructure OF2506 Dockerfiles

### DIFF
--- a/.github/workflows/docker-dependencies.yml
+++ b/.github/workflows/docker-dependencies.yml
@@ -1,0 +1,69 @@
+name: Build Dependencies Docker Images
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ithacafv/ithacafv-dependencies
+
+jobs:
+  build-amd64-deps:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push AMD64 dependencies
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: ./dockerfiles/OF2506/amd64-deps
+        platforms: linux/amd64
+        push: true
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:amd64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+  build-arm64-deps:
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log into registry ${{ env.REGISTRY }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push ARM64 dependencies
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: ./dockerfiles/OF2506/arm64-deps
+        platforms: linux/arm64
+        push: true
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/dockerfiles/OF2412/Dockerfile
+++ b/dockerfiles/OF2412/Dockerfile
@@ -3,7 +3,7 @@
 ARG TARGETARCH
 FROM ithacafv/openfoam2412-muq2-pytorch:${TARGETARCH} AS base
 
-LABEL maintainer="moaadkhamlich@gmail.com"
+LABEL maintainer="giovannistabile@santannapisa.it"
 
 USER root
 

--- a/dockerfiles/OF2506/Dockerfile
+++ b/dockerfiles/OF2506/Dockerfile
@@ -1,31 +1,75 @@
-# Start from the ubuntu Openfoam 2106 image
-FROM opencfd/openfoam-dev:2506
+# Multi-architecture Dockerfile for ITHACA-FV
+# Automatically selects the correct base image based on target platform
+ARG TARGETARCH
+FROM ithacafv/openfoam2506-muq2-pytorch:${TARGETARCH} AS base
+
+LABEL maintainer="giovannistabile@santannapisa.it"
+
 USER root
-ARG PYTHON_VERSION=3.7
-ENV PATH="/root/miniconda3/bin:${PATH}"
 
-RUN rm /etc/apt/sources.list.d/openfoam.list && \
-    cp /etc/apt/sources.list /etc/apt/sources.list.backup && \
-    grep -v -e "openfoam" /etc/apt/sources.list.backup > /etc/apt/sources.list && \
-    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
-    apt-get install -yy -q pwgen npm nodejs cmake git wget bzip2 unzip && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Install additional packages
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        vim \
+        ssh \
+        sudo \
+        wget \
+        software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
 
-# Anaconda installing
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-bash Miniconda3-latest-Linux-x86_64.sh -b && \
-rm Miniconda3-latest-Linux-x86_64.sh && \
-. /root/miniconda3/etc/profile.d/conda.sh && \  
-export PATH=/root/miniconda3/bin:$PATH && \
-wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.1%2Bcpu.zip && \
-unzip libtorch-cxx11-abi-shared-with-deps-2.7.1+cpu.zip && \
-rm libtorch-cxx11-abi-shared-with-deps-2.7.1+cpu.zip && \
-conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
-conda tos accept --override-channels --channel  https://repo.anaconda.com/pkgs/r && \
-conda install -y -c conda-forge muq cmake pybind11 && \
-conda clean -y --all
-ENV TORCH_LIBRARIES=/libtorch
-ENV MUQ_LIBRARIES=/root/miniconda3
-RUN echo 'source /usr/lib/openfoam/openfoam2506/etc/bashrc' >> ~/.bashrc 
+# Create ithacafv user and group
+ARG USER=ithacafv
+RUN if id -u 1000 >/dev/null 2>&1; then \
+        userdel $(id -nu 1000) || true; \
+    fi && \
+    if getent group 1000 >/dev/null 2>&1; then \
+        groupdel $(getent group 1000 | cut -d: -f1) || true; \
+    fi && \
+    adduser --disabled-password --gecos '' --uid 1000 $USER && \
+    adduser $USER sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
+# Set environment variables
+ENV HOME=/home/$USER
+ENV USER=$USER
+
+# Set working directory and clone ITHACA-FV
+WORKDIR /opt
+RUN git clone https://github.com/mathLab/ITHACA-FV.git && \
+    chown -R $USER:$USER ITHACA-FV && \
+    chown -R $USER:$USER /home/$USER
+
+# Environment variables for bashrc
+ARG of_var="source /usr/lib/openfoam/openfoam2412/etc/bashrc"
+ARG ithaca_var="source /opt/ITHACA-FV/etc/bashrc"
+
+# Update bashrc with OpenFOAM and ITHACA-FV sources
+RUN echo $of_var >> /etc/bash.bashrc && \
+    echo $ithaca_var >> /etc/bash.bashrc
+
+# Switch to ithacafv user
+USER $USER
+
+# Build ITHACA-FV
+RUN /bin/bash -c "source /usr/lib/openfoam/openfoam2412/etc/bashrc && \
+    cd ITHACA-FV && \
+    git submodule update --init && \
+    source etc/bashrc && \
+    ./Allwmake -au -j 4"
+
+# Copy binaries and libraries to system paths (as root)
+USER root
+RUN if [ -d "/home/$USER/OpenFOAM/$USER-openfoam2412/platforms/linux64GccDPInt32Opt/bin" ]; then \
+        cp -r /home/$USER/OpenFOAM/$USER-openfoam2412/platforms/linux64GccDPInt32Opt/bin/* /usr/local/bin/ || true; \
+        cp -r /home/$USER/OpenFOAM/$USER-openfoam2412/platforms/linux64GccDPInt32Opt/lib/* /usr/local/lib/ || true; \
+    fi
+
+# Final setup
+USER $USER
+WORKDIR $HOME
+
+# Source bashrc on container start
+RUN /bin/bash -c "source /etc/bash.bashrc"
+
+ENTRYPOINT ["/bin/bash"]

--- a/dockerfiles/OF2506/Makefile
+++ b/dockerfiles/OF2506/Makefile
@@ -1,9 +1,0 @@
-ME=$(shell whoami)
-clean:
-	rm -f hello
-
-build:
-	docker build -t ithacafv/openfoam2506-muq2-pytorch -f ./Dockerfile .
-
-run: 
-	docker run -it ithacafv/openfoam2506-muq2-pytorch bash

--- a/dockerfiles/OF2506/amd64-deps/Dockerfile
+++ b/dockerfiles/OF2506/amd64-deps/Dockerfile
@@ -1,0 +1,30 @@
+# Start from the ubuntu Openfoam 2106 image
+FROM opencfd/openfoam-dev:2506
+USER root
+ARG PYTHON_VERSION=3.7
+ENV PATH="/root/miniconda3/bin:${PATH}"
+
+RUN rm /etc/apt/sources.list.d/openfoam.list && \
+    cp /etc/apt/sources.list /etc/apt/sources.list.backup && \
+    grep -v -e "openfoam" /etc/apt/sources.list.backup > /etc/apt/sources.list && \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -yy -q pwgen npm nodejs cmake git wget bzip2 unzip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Anaconda installing
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+bash Miniconda3-latest-Linux-x86_64.sh -b && \
+rm Miniconda3-latest-Linux-x86_64.sh && \
+. /root/miniconda3/etc/profile.d/conda.sh && \
+export PATH=/root/miniconda3/bin:$PATH && \
+wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.1%2Bcpu.zip && \
+unzip libtorch-cxx11-abi-shared-with-deps-2.7.1+cpu.zip && \
+rm libtorch-cxx11-abi-shared-with-deps-2.7.1+cpu.zip && \
+conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+conda tos accept --override-channels --channel  https://repo.anaconda.com/pkgs/r && \
+conda install -y -c conda-forge muq cmake pybind11 && \
+conda clean -y --all
+ENV TORCH_LIBRARIES=/libtorch
+ENV MUQ_LIBRARIES=/root/miniconda3
+RUN echo 'source /usr/lib/openfoam/openfoam2412/etc/bashrc' >> ~/.bashrc

--- a/dockerfiles/OF2506/arm64-deps/Dockerfile
+++ b/dockerfiles/OF2506/arm64-deps/Dockerfile
@@ -1,0 +1,36 @@
+# Start from the ubuntu Openfoam 2106 image
+FROM opencfd/openfoam-dev:2505
+USER root
+ARG PYTHON_VERSION=3.7
+ENV PATH="/root/miniconda3/bin:${PATH}"
+
+RUN rm /etc/apt/sources.list.d/openfoam.list && \
+    cp /etc/apt/sources.list /etc/apt/sources.list.backup && \
+    grep -v -e "openfoam" /etc/apt/sources.list.backup > /etc/apt/sources.list && \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -yy -q pwgen npm nodejs cmake git wget bzip2 unzip libc6-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Anaconda installing
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh && \
+bash Miniconda3-latest-Linux-aarch64.sh -b && \
+rm Miniconda3-latest-Linux-aarch64.sh && \
+. /root/miniconda3/etc/profile.d/conda.sh && \
+export PATH=/root/miniconda3/bin:$PATH && \
+wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.1%2Bcpu.zip && \
+unzip libtorch-cxx11-abi-shared-with-deps-2.7.1+cpu.zip && \
+rm libtorch-cxx11-abi-shared-with-deps-2.7.1+cpu.zip && \
+conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
+conda tos accept --override-channels --channel  https://repo.anaconda.com/pkgs/r && \
+conda install -y -c conda-forge cmake pybind11 eigen hdf5 nlopt && \
+git clone https://bitbucket.org/mituq/muq2.git /tmp/muq2 && \
+cd /tmp/muq2 && rm -rf build && mkdir build && cd build && \
+cmake -DCMAKE_INSTALL_PREFIX=/root/miniconda3 -DMUQ_USE_PYTHON=ON .. && \
+make -j4 && make install && \
+cd / && rm -rf /tmp/muq2 && \
+conda clean -y --all
+ENV TORCH_LIBRARIES=/libtorch
+ENV MUQ_LIBRARIES=/root/miniconda3
+RUN echo 'source /usr/lib/openfoam/openfoam2412/etc/bashrc' >> ~/.bashrc
+


### PR DESCRIPTION
- Add new docker-dependencies.yml workflow for manual dependency builds
- Split OF2506 Dockerfile into main and separate dependency builds
- Create architecture-specific dependency Dockerfiles (amd64-deps, arm64-deps)
- Update maintainer labels to giovannistabile@santannapisa.it
- Remove unused Makefile from OF2506 directory
- Configure dependencies workflow to push to ithacafv/ithacafv-dependencies