### PR TITLE
Modify std::cout to Info

### DIFF
--- a/applications/POD/perform_POD.C
+++ b/applications/POD/perform_POD.C
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     if(pod_exist == 1)
     {
         Info << "The POD has already been performed, please delete the ITHACAoutput folder and try again." << endl;
-        exit(0);
+        return 0;
     }
 
     // Initialize Variables

--- a/src/ITHACA_CORE/Containers/Modes.C
+++ b/src/ITHACA_CORE/Containers/Modes.C
@@ -455,7 +455,7 @@ void Modes<Type, PatchField, GeoMesh>::projectSnapshots(
         }
         else
         {
-            std::cout << "Inner product not defined" << endl;
+            Foam::Info << "Inner product not defined" << Foam::endl;
             exit(0);
         }
 

--- a/src/ITHACA_CORE/ITHACAPOD/ITHACAPOD.C
+++ b/src/ITHACA_CORE/ITHACAPOD/ITHACAPOD.C
@@ -160,7 +160,7 @@ void getModes(
         if (para->eigensolver == "spectra")
         {
             Spectra::SymEigsSolver<Spectra::DenseSymMatProd<double>> es(op, nmodes, ncv);
-            std::cout << "Using Spectra EigenSolver " << std::endl;
+            Info << "Using Spectra EigenSolver " << endl;
             es.init();
             es.compute(Spectra::SortRule::LargestAlge);
             M_Assert(es.info() == Spectra::CompInfo::Successful,
@@ -170,7 +170,7 @@ void getModes(
         }
         else if (para->eigensolver == "eigen")
         {
-            std::cout << "Using Eigen EigenSolver " << std::endl;
+            Info << "Using Eigen EigenSolver " << endl;
             esEg.compute(_corMatrix);
             M_Assert(esEg.info() == Eigen::Success,
                      "The Eigenvalue Decomposition did not succeed");
@@ -250,7 +250,8 @@ void getModes(
             modesEigBC[i] = (SnapMatrixBC[i] * eigenVectoreig);
         }
 
-        std::cout << normFact << std::endl;
+        Info << endl << "####### Normalized Eigenvalues of " << snapshots[0].name() 
+            << " #######" << endl << normFact << endl << endl;
 
         for (label i = 0; i < nmodes; i++)
         {
@@ -369,7 +370,7 @@ void getModesMemoryEfficient(
         fileName rootPath(".");
         Foam::Time runTime2(Foam::Time::controlDictName, rootPath, snapshotsPath);
         label nSnaps = runTime2.times().size() - 2;
-        std::cout << "Found " << nSnaps << " time directories" << endl;
+        Info << "Found " << nSnaps << " time directories" << endl;
 
         // Verify we have at least one snapshot
         if (nSnaps < 1)
@@ -482,7 +483,7 @@ void getModesMemoryEfficient(
         if (para->eigensolver == "spectra")
         {
             // Use Spectra solver for large eigenvalue problems
-            std::cout << "Using Spectra EigenSolver " << std::endl;
+            Info << "Using Spectra EigenSolver " << endl;
             Spectra::DenseSymMatProd<double> op(_corMatrix);
             Spectra::SymEigsSolver<Spectra::DenseSymMatProd<double >>
             solver(op, nmodes, nSnaps);
@@ -496,7 +497,7 @@ void getModesMemoryEfficient(
         else if (para->eigensolver == "eigen")
         {
             // Use Eigen solver for smaller problems
-            std::cout << "Using Eigen EigenSolver " << std::endl;
+            Info << "Using Eigen EigenSolver " << endl;
             Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(_corMatrix);
             M_Assert(solver.info() == Eigen::Success,
                      "Eigenvalue decomposition failed");
@@ -666,7 +667,7 @@ void getMeanMemoryEfficient(
     fileName rootPath(".");
     Foam::Time runTime2(Foam::Time::controlDictName, rootPath, snapshotsPath);
     label nSnaps = runTime2.times().size() - 2;
-    std::cout << "Found " << nSnaps << " time directories" << endl;
+    Info << "Found " << nSnaps << " time directories" << endl;
 
     // Compute mean field
     if (!meanex)
@@ -746,7 +747,7 @@ void getWeightedModes(
 
         if (para->eigensolver == "spectra")
         {
-            std::cout << "Using Spectra EigenSolver " << std::endl;
+            Info << "Using Spectra EigenSolver " << endl;
             es.init();
             es.compute(Spectra::SortRule::LargestAlge);
             M_Assert(es.info() == Spectra::CompInfo::Successful,
@@ -756,7 +757,7 @@ void getWeightedModes(
         }
         else if (para->eigensolver == "eigen")
         {
-            std::cout << "Using Eigen EigenSolver " << std::endl;
+            Info << "Using Eigen EigenSolver " << endl;
             esEg.compute(_corMatrix);
             M_Assert(esEg.info() == Eigen::Success,
                      "The Eigenvalue Decomposition did not succeed");
@@ -1179,9 +1180,9 @@ DEIMmodes(List<Eigen::SparseMatrix<double >>& A,
     {
         if (nmodesA > A.size() - 2 || nmodesB > A.size() - 2 )
         {
-            std::cout <<
+            Info <<
             "The number of requested modes cannot be bigger than the number of Snapshots - 2"
-                      << std::endl;
+                      << endl;
             exit(0);
         }
 
@@ -1433,7 +1434,7 @@ void getModes(
             }
         }
 
-        std::cout << std::endl;
+        Info << endl;
 
         for (label i = 1; i < snapshots.size(); i++)
         {
@@ -1456,7 +1457,7 @@ void getModes(
         {
             Spectra::SymEigsSolver< Spectra::DenseSymMatProd<double >>
             es(op, nmodes, ncv);
-            std::cout << "Using Spectra EigenSolver " << std::endl;
+            Info << "Using Spectra EigenSolver " << endl;
             es.init();
             es.compute(Spectra::SortRule::LargestAlge);
             M_Assert(es.info() == Spectra::CompInfo::Successful,
@@ -1466,7 +1467,7 @@ void getModes(
         }
         else if (para->eigensolver == "eigen")
         {
-            std::cout << "Using Eigen EigenSolver " << std::endl;
+            Info << "Using Eigen EigenSolver " << endl;
             esEg.compute(_corMatrix);
             M_Assert(esEg.info() == Eigen::Success,
                      "The Eigenvalue Decomposition did not succeed");
@@ -1800,7 +1801,7 @@ PtrList<GeometricField<Type, PatchField, GeoMesh >> DEIMmodes(
         {
             Spectra::SymEigsSolver< Spectra::DenseSymMatProd<double >>
             es(op, nmodes, ncv);
-            std::cout << "Using Spectra EigenSolver " << std::endl;
+            Info << "Using Spectra EigenSolver " << endl;
             es.init();
             es.compute(Spectra::SortRule::LargestAlge);
             M_Assert(es.info() == Spectra::CompInfo::Successful,
@@ -1810,7 +1811,7 @@ PtrList<GeometricField<Type, PatchField, GeoMesh >> DEIMmodes(
         }
         else if (para->eigensolver == "eigen")
         {
-            std::cout << "Using Eigen EigenSolver " << std::endl;
+            Info << "Using Eigen EigenSolver " << endl;
             esEg.compute(_corMatrix);
             M_Assert(esEg.info() == Eigen::Success,
                      "The Eigenvalue Decomposition did not succeed");
@@ -1874,7 +1875,7 @@ PtrList<GeometricField<Type, PatchField, GeoMesh >> DEIMmodes(
             modesEigBC[i] = (SnapMatrixBC[i] * eigenVectoreig);
         }
 
-        std::cout << normFact << std::endl;
+        Info << normFact << endl;
 
         for (label i = 0; i < nmodes; i++)
         {
@@ -1991,7 +1992,7 @@ void getModes(
         {
             Spectra::SymEigsSolver<Spectra::DenseSymMatProd<double >>
             es(op, nmodes, ncv);
-            std::cout << "Using Spectra EigenSolver " << std::endl;
+            Info << "Using Spectra EigenSolver " << endl;
             es.init();
             es.compute(Spectra::SortRule::LargestAlge);
             M_Assert(es.info() == Spectra::CompInfo::Successful,
@@ -2001,7 +2002,7 @@ void getModes(
         }
         else if (para->eigensolver == "eigen")
         {
-            std::cout << "Using Eigen EigenSolver " << std::endl;
+            Info << "Using Eigen EigenSolver " << endl;
             esEg.compute(_corMatrix);
             M_Assert(esEg.info() == Eigen::Success,
                      "The Eigenvalue Decomposition did not succeed");

--- a/src/ITHACA_CORE/ITHACAPOD/incrementalPOD.C
+++ b/src/ITHACA_CORE/ITHACAPOD/incrementalPOD.C
@@ -316,7 +316,7 @@ incrementalPOD<Type, PatchField, GeoMesh>::projectSnapshot(
     }
     else
     {
-        std::cout << "Inner product not defined" << endl;
+        Foam::Info << "Inner product not defined" << Foam::endl;
         exit(0);
     }
 
@@ -367,7 +367,7 @@ void incrementalPOD<Type, PatchField, GeoMesh>::projectSnapshots(
         }
         else
         {
-            std::cout << "Inner product not defined" << endl;
+            Foam::Info << "Inner product not defined" << Foam::endl;
             exit(0);
         }
 

--- a/src/ITHACA_CORE/ITHACAregularization/ITHACAregularization.C
+++ b/src/ITHACA_CORE/ITHACAregularization/ITHACAregularization.C
@@ -115,9 +115,9 @@ Eigen::VectorXd  Tikhonov(Eigen::MatrixXd A,
                            Eigen::MatrixXd::Identity(A.rows(), A.cols());
     Eigen::MatrixXd bNew = A.transpose() * b;
     Eigen::VectorXd x = A.inverse() * b;
-    std::cout << "x = \n" << x.transpose() << std::endl;
+    Info << "x = \n" << x.transpose() << endl;
     x = Anew.inverse() * bNew;
-    std::cout << "xNew = \n" << x.transpose() << std::endl;
+    Info << "xNew = \n" << x.transpose() << endl;
     return x;
 }
 }

--- a/src/ITHACA_CORE/ITHACAsensitivity/FiguresOfMerit/Ptot.C
+++ b/src/ITHACA_CORE/ITHACAsensitivity/FiguresOfMerit/Ptot.C
@@ -38,7 +38,7 @@ void Ptot::buildMO(std::string dir)
     }
     else
     {
-        std::cout << "Outputs of the model are not computed yet, programm aborted" <<
-                  std::endl;
+        Foam::Info << "Outputs of the model are not computed yet, programm aborted" <<
+                  Foam::endl;
     }
 }

--- a/src/ITHACA_CORE/ITHACAsensitivity/FiguresOfMerit/Ptot_time.C
+++ b/src/ITHACA_CORE/ITHACAsensitivity/FiguresOfMerit/Ptot_time.C
@@ -45,7 +45,7 @@ void Ptot_time::buildMO(std::string dir, label t)
     }
     else
     {
-        std::cout << "Outputs of the model are not computed yet, programm aborted" <<
-                  std::endl;
+        Foam::Info << "Outputs of the model are not computed yet, programm aborted" <<
+                  Foam::endl;
     }
 }

--- a/src/ITHACA_CORE/ITHACAsensitivity/FiguresOfMerit/Tm.C
+++ b/src/ITHACA_CORE/ITHACAsensitivity/FiguresOfMerit/Tm.C
@@ -38,8 +38,8 @@ void Tm::buildMO(std::string dir)
     }
     else
     {
-        std::cout << "Outputs of the model are not computed yet, programm aborted" <<
-                  std::endl;
+        Foam::Info << "Outputs of the model are not computed yet, programm aborted" <<
+                  Foam::endl;
         exit(0);
     }
 }

--- a/src/ITHACA_CORE/ITHACAsensitivity/FiguresOfMerit/Tm_time.C
+++ b/src/ITHACA_CORE/ITHACAsensitivity/FiguresOfMerit/Tm_time.C
@@ -45,8 +45,8 @@ void Tm_time::buildMO(std::string dir, label t)
     }
     else
     {
-        std::cout << "Outputs of the model are not computed yet, programm aborted" <<
-                  std::endl;
+        Foam::Info << "Outputs of the model are not computed yet, programm aborted" <<
+                  Foam::endl;
         exit(0);
     }
 }

--- a/src/ITHACA_CORE/ITHACAsensitivity/ITHACAsampling.C
+++ b/src/ITHACA_CORE/ITHACAsensitivity/ITHACAsampling.C
@@ -67,8 +67,8 @@ Eigen::VectorXd ITHACAsampling::samplingMC(std::string pdftype, double& lowerE,
     }
     else
     {
-        std::cout << "pdf '" << pdftype << "' not implemented, programm aborted" <<
-                  std::endl;
+        Foam::Info << "pdf '" << pdftype << "' not implemented, programm aborted" <<
+                  Foam::endl;
         exit(0);
     }
 

--- a/src/ITHACA_CORE/ITHACAsensitivity/LRSensitivity.C
+++ b/src/ITHACA_CORE/ITHACAsensitivity/LRSensitivity.C
@@ -56,8 +56,8 @@ void LRSensitivity::load_output()
     }
     else
     {
-        std::cout << "Model output not computed or assigned, program aborted" <<
-                  std::endl;
+        Foam::Info << "Model output not computed or assigned, program aborted" <<
+                  Foam::endl;
         exit(0);
     }
 }
@@ -118,9 +118,9 @@ void LRSensitivity::getBetas()
     }
     else
     {
-        std::cout <<
+        Foam::Info <<
         "Statistics about inputs or output are not computed yet, nothing to do ..." <<
-                  std::endl;
+                  Foam::endl;
     }
 }
 
@@ -149,9 +149,9 @@ void LRSensitivity::assessQuality()
     }
     else
     {
-        std::cout <<
+        Foam::Info <<
         "Linear regression coefficients are not computed yet, nothing to do ..." <<
-                  std::endl;
+                  Foam::endl;
     }
 }
 

--- a/src/ITHACA_CORE/ITHACAstream/ITHACAstream.C
+++ b/src/ITHACA_CORE/ITHACAstream/ITHACAstream.C
@@ -138,7 +138,7 @@ void exportMatrix(Eigen::Matrix < T, -1, dim > & matrix,
 
             if (i != (matrix.rows() - 1))
             {
-                ofs << std::endl;
+                ofs << endl;
             }
         }
 
@@ -584,7 +584,7 @@ void read_fields(
             }
         }
 
-        std::cout << std::endl;
+        Info << endl;
     }
     else
     {
@@ -727,7 +727,7 @@ void read_fields(
             }
         }
 
-        std::cout << std::endl;
+        Info << endl;
     }
     else
     {
@@ -804,8 +804,7 @@ void readConvergedFields(
     int par = 1;
     M_Assert(ITHACAutilities::check_folder(casename + "/" + name(par)) != 0,
              "No parameter dependent solutions stored into Offline folder");
-    std::cout << "######### Reading the Data for " << field.name() << " #########"
-              << std::endl;
+    Info << "######### Reading the Data for " << field.name() << " #########" << endl;
 
     while (ITHACAutilities::check_folder(casename + "/" + name(par)))
     {
@@ -872,7 +871,7 @@ void read_last_fields(
             );
         Lfield.append(std::move(tfld));
 #endif
-        std::cout << std::endl;
+        Info << endl;
     }
     else
     {
@@ -968,7 +967,7 @@ void exportFields(
         printProgress(double(j + 1) / field.size());
     }
 
-    std::cout << std::endl;
+    Info << endl;
 }
 
 template void exportFields(
@@ -1009,7 +1008,6 @@ void exportSolution(GeometricField<Type, PatchField, GeoMesh>& s,
         GeometricField<Type, PatchField, GeoMesh> act(fieldName, s);
         fileName fieldname = folder + "/processor" + name(Pstream::myProcNo()) + "/" +
                              subfolder + "/" + fieldName;
-        std::cout << fieldname << std::endl;
         OFstream os(fieldname);
         act.writeHeader(os);
         os << act << endl;
@@ -1146,7 +1144,7 @@ void load(List<Eigen::SparseMatrix<T >>& MatrixList, word folder,
           word MatrixName)
 {
     int number_of_files = numberOfFiles(folder, MatrixName, ".npz");
-    std::cout << "Reading the Matrix " + folder + "/" + MatrixName << std::endl;
+    Info << "Reading the Matrix " + folder + "/" + MatrixName << endl;
     M_Assert(number_of_files != 0,
              "Check if the file you are trying to read exists" );
     MatrixList.resize(0);

--- a/src/ITHACA_CORE/ITHACAstream/ITHACAstream.H
+++ b/src/ITHACA_CORE/ITHACAstream/ITHACAstream.H
@@ -64,6 +64,7 @@ SourceFiles
 #pragma GCC diagnostic ignored "-Wignored-attributes"
 #include <Eigen/Eigen>
 #include "EigenFunctions.H"
+#include "colormod.H"
 
 #include <unsupported/Eigen/CXX11/Tensor>
 #pragma GCC diagnostic pop
@@ -548,7 +549,7 @@ namespace Foam
 template<typename T>
 Ostream& operator<< (Ostream& os, const Eigen::Matrix < T, -1, -1 > & mat)
 {
-    os << mat.rows() << mat.cols() << UList<T>(const_cast<Eigen::MatrixXd&>
+    os << mat.rows() << mat.cols() << UList<T>(const_cast<Eigen::Matrix<T, -1, -1>&>
             (mat).data(), mat.size());
     return os;
 }
@@ -567,7 +568,7 @@ Istream& operator>> (Istream& is, Eigen::Matrix < T, -1, -1 > & mat)
 template<typename T>
 Ostream& operator<< (Ostream& os, const Eigen::Matrix < T, -1, 1 > & mat)
 {
-    os << mat.rows() << mat.cols() << UList<T>(const_cast<Eigen::VectorXd&>
+    os << mat.rows() << mat.cols() << UList<T>(const_cast<Eigen::Matrix<T, -1, 1>&>
             (mat).data(), mat.size());
     return os;
 }
@@ -581,6 +582,24 @@ Istream& operator>> (Istream& is, Eigen::Matrix < T, -1, 1 > & mat)
     UList<T> list(mat.data(), nrow * ncol);
     is >> list;
     return is;
+}
+
+// Support for Eigen matrix transpose expression
+template<typename T>
+Ostream& operator<< (Ostream& os, const Eigen::Transpose<Eigen::Matrix<T, -1, -1>>& mat)
+{
+    Eigen::Matrix<T, -1, -1> evaluated = mat;
+    os << evaluated.rows() << evaluated.cols() << UList<T>(evaluated.data(), evaluated.size());
+    return os;
+}
+
+// Support for Eigen vector transpose expression
+template<typename T>
+Ostream& operator<< (Ostream& os, const Eigen::Transpose<Eigen::Matrix<T, -1, 1>>& mat)
+{
+    Eigen::Matrix<T, 1, -1> evaluated = mat;
+    os << evaluated.rows() << evaluated.cols() << UList<T>(evaluated.data(), evaluated.size());
+    return os;
 }
 
 template<typename T>
@@ -601,6 +620,13 @@ Istream& operator>> (Istream& is, Eigen::Tensor<T, 3>& tens)
     UList<T> list(tens.data(), d1 * d2 * d3);
     is >> list;
     return is;
+}
+
+inline Ostream& operator<<(Ostream& os, const Color::Modifier& mod)
+{
+    // Output ANSI code to Foam Ostream
+    os << "\033[" << int(mod.getCode()) << "m";
+    return os;
 }
 
 }
@@ -648,8 +674,8 @@ void ITHACAstream::ReadSparseMatrix(Eigen::SparseMatrix<T, whatever, IND>& m,
 
     if (!readFile.good())
     {
-        std::cout << folder + MatrixName <<
-        " file does not exist, try to rerun the Offline Stage!" << std::endl;
+        Foam::Info << folder + MatrixName <<
+        " file does not exist, try to rerun the Offline Stage!" << Foam::endl;
         exit(EXIT_FAILURE);
     }
     else if (readFile.is_open())
@@ -697,8 +723,8 @@ void ITHACAstream::ReadDenseMatrix(MatrixType& Matrix, word folder,
 
     if (!in.good())
     {
-        std::cout << folder + MatrixName <<
-        " file does not exist, try to rerun the Offline Stage!" << std::endl;
+        Foam::Info << folder + MatrixName <<
+        " file does not exist, try to rerun the Offline Stage!" << Foam::endl;
         exit(EXIT_FAILURE);
     }
     else if (in.is_open())
@@ -785,7 +811,7 @@ void ITHACAstream::ReadSparseMatrixList(
     List<Eigen::SparseMatrix<T, whatever, IND >>& m, word folder, word MatrixName)
 {
     int number_of_files = numberOfFiles(folder, MatrixName);
-    std::cout << "Reading the Matrix " + folder + MatrixName << std::endl;
+    Foam::Info << "Reading the Matrix " + folder + MatrixName << Foam::endl;
     M_Assert(number_of_files != 0,
              "Check if the file you are trying to read exists" );
     Eigen::SparseMatrix<T, whatever, IND> A;
@@ -803,7 +829,7 @@ void ITHACAstream::ReadDenseMatrixList(List<MatrixType>& m, word folder,
                                        word MatrixName)
 {
     int number_of_files = numberOfFiles(folder, MatrixName);
-    std::cout << "Reading the Matrix " + folder + MatrixName << std::endl;
+    Foam::Info << "Reading the Matrix " + folder + MatrixName << Foam::endl;
     M_Assert(number_of_files != 0,
              "Check if the file you are trying to read exists" );
     MatrixType A;

--- a/src/ITHACA_CORE/ITHACAstream/cnpy.C
+++ b/src/ITHACA_CORE/ITHACAstream/cnpy.C
@@ -358,7 +358,7 @@ cnpy::NpyArray load_the_npz_array(FILE* fp, uint32_t compr_bytes,
 cnpy::npz_t cnpy::npz_load(std::string fname)
 {
     FILE* fp = fopen(fname.c_str(), "rb");
-    std::cerr << "Line: 350 of file cnpy.C" << std::endl;
+    std::cerr << "Line: 350 of file cnpy.C" << endl;
 
     if (!fp)
     {
@@ -371,7 +371,7 @@ cnpy::npz_t cnpy::npz_load(std::string fname)
     {
         std::vector<char> local_header(30);
         size_t headerres = fread(&local_header[0], sizeof(char), 30, fp);
-        std::cerr << headerres << std::endl;
+        std::cerr << headerres << endl;
 
         if (headerres != 30)
         {

--- a/src/ITHACA_CORE/ITHACAstream/cnpy.H
+++ b/src/ITHACA_CORE/ITHACAstream/cnpy.H
@@ -219,14 +219,14 @@ template<typename T> void npy_save(std::string fname, const T* data,
 
         if (word_size != sizeof(T))
         {
-            std::cout << "libnpy error: " << fname << " has word size " << word_size <<
+            Foam::Info << "libnpy error: " << fname << " has word size " << word_size <<
                          " but npy_save appending data sized " << sizeof(T) << "\n";
             assert( word_size == sizeof(T) );
         }
 
         if (true_data_shape.size() != shape.size())
         {
-            std::cout <<
+            Foam::Info <<
             "libnpy error: npy_save attempting to append misdimensioned data to " << fname
                       << "\n";
             assert(true_data_shape.size() != shape.size());
@@ -236,7 +236,7 @@ template<typename T> void npy_save(std::string fname, const T* data,
         {
             if (shape[i] != true_data_shape[i])
             {
-                std::cout << "libnpy error: npy_save attempting to append misshaped data to " <<
+                Foam::Info << "libnpy error: npy_save attempting to append misshaped data to " <<
                           fname << "\n";
                 assert(shape[i] == true_data_shape[i]);
             }

--- a/src/ITHACA_CORE/ITHACAutilities/colormod.H
+++ b/src/ITHACA_CORE/ITHACAutilities/colormod.H
@@ -26,6 +26,8 @@ class Modifier
     public:
         Modifier(Code pCode) : code(pCode) {}
 
+        Code getCode() const { return code; }
+
         friend std::ostream&
         operator<<(std::ostream& os, const Modifier& mod)
         {

--- a/src/ITHACA_FOMPROBLEMS/CompressibleSteadyNS/CompressibleSteadyNS.C
+++ b/src/ITHACA_FOMPROBLEMS/CompressibleSteadyNS/CompressibleSteadyNS.C
@@ -284,7 +284,7 @@ void CompressibleSteadyNS::restart()
     Info << "ReCreate time\n" << Foam::endl;
     // _runTime = autoPtr<Foam::Time>( new Foam::Time( Foam::Time::controlDictName,
     //                                 args ) );
-    // std::cerr << "File: CompressibleSteadyNS.C, Line: 281" << std::endl;
+    // std::cerr << "File: CompressibleSteadyNS.C, Line: 281" << endl;
     Time& runTime = _runTime();
     runTime.setTime(0, 1);
     // _mesh = autoPtr<fvMesh>

--- a/src/ITHACA_FOMPROBLEMS/CompressibleSteadyNS/NLsolve.H
+++ b/src/ITHACA_FOMPROBLEMS/CompressibleSteadyNS/NLsolve.H
@@ -138,14 +138,14 @@ while (simple.loop() && residual > tolerance && csolve < maxIter )
     rho.relax();
     auto uresidual = max(max(uresidual_v[0], uresidual_v[1]), uresidual_v[2]);
     residual = max(max(presidual, uresidual), eresidual);
-    Info << "\nResidual: " << residual << endl << endl;
+    Foam::Info << "\nResidual: " << residual << Foam::endl << Foam::endl;
     turbulence->correct();
     csolve = csolve + 1;
-    Info << "ExecutionTime = " << runTime.elapsedCpuTime() << " s"
+    Foam::Info << "ExecutionTime = " << runTime.elapsedCpuTime() << " s"
          << "  ClockTime = "   << runTime.elapsedClockTime() << " s"
-         << nl << endl;
+         << Foam::endl << Foam::endl;
     saver++;
-    std::cout << "saver ================== \t" << saver << std::endl;
+    Foam::Info << "saver ================== \t" << saver << Foam::endl;
 
     if (middleExport && saver == middleStep)
     {

--- a/src/ITHACA_FOMPROBLEMS/Fsi/fsiBasic.C
+++ b/src/ITHACA_FOMPROBLEMS/Fsi/fsiBasic.C
@@ -504,8 +504,8 @@ void fsiBasic::loadCentreOfMassY(const fileName& baseDir)
             Eigen::MatrixXd CentreOfMassY;
             cnpy::load(CentreOfMassY, targetFile);
             Eigen::VectorXd currentVec = CentreOfMassY.col(0);
-            // std::cout << "CentreOfMassY dimensions: "
-            //          << CentreOfMassY.rows() << " x " << CentreOfMassY.cols() << std::endl;
+            // Info << "CentreOfMassY dimensions: "
+            //          << CentreOfMassY.rows() << " x " << CentreOfMassY.cols() << endl;
             vecOfCentreOfMasses.conservativeResize(vecOfCentreOfMasses.size() +
                                                    currentVec.size());
             vecOfCentreOfMasses.tail(currentVec.size()) = currentVec;
@@ -517,7 +517,7 @@ void fsiBasic::loadCentreOfMassY(const fileName& baseDir)
         }
     }
     this->CylDispl = vecOfCentreOfMasses;
-    // std::cout << "=== vecOfCentereOfMasses size ===" << vecOfCentreOfMasses.size() << std::endl;
+    // Info << "=== vecOfCentereOfMasses size ===" << vecOfCentreOfMasses.size() << endl;
 }
 
 

--- a/src/ITHACA_FOMPROBLEMS/ScalarTransport/ScalarTransport.C
+++ b/src/ITHACA_FOMPROBLEMS/ScalarTransport/ScalarTransport.C
@@ -185,7 +185,7 @@ void ScalarTransport::restart()
 //         startTime  = problem->startTime;
 //         writeEvery = problem->writeEvery;
 
-//         std::cout << "######## reduced Constructor calling ##########"<< std::endl;
+//         Info << "######## reduced Constructor calling ##########"<< endl;
 //     }
 
 //     ~EliBurgers(){}
@@ -318,8 +318,8 @@ void ScalarTransport::restart()
 //                 /// Hyper-reduced system
 //                 /// TODO: make sure to include the values of the volumes.
 //                 Eigen::VectorXd a = solver.compute(Se).solve(se);
-//                 //std::cout << "a.rows() = " << a.rows() << std::endl;
-//                 //std::cout << "a.cols() = " << a.cols() << std::endl;
+//                 //Info << "a.rows() = " << a.rows() << endl;
+//                 //Info << "a.cols() = " << a.cols() << endl;
 //                 //Eigen::VectorXd z = Y*a;
 //                 //exit(0);
 //                 /// Solution in eigen format
@@ -329,7 +329,7 @@ void ScalarTransport::restart()
 
 //             if (checkWrite(problem->_runTime()))
 //             {
-//                 //std::cout << "########## line 190" << std::endl;
+//                 //Info << "########## line 190" << endl;
 //                 //ITHACAstream::exportSolution(S, name(counter), folder);
 //                 counter++;
 //                 Ufield.append(S.clone());
@@ -377,7 +377,7 @@ void ScalarTransport::restart()
 //     startOff= std::clock();
 //     train.offlineSolve();
 //     durationOff = (std::clock() - startOff);
-//     std::cout << "The Offline phase duration is equal to" << durationOff << std::endl;
+//     Info << "The Offline phase duration is equal to" << durationOff << endl;
 //     // ITHACAPOD::getModes(train.Ufield, train.Umodes, train._U().name(),
 //     //                    train.podex, 0, 0,NmodesUout);
 
@@ -406,8 +406,8 @@ void ScalarTransport::restart()
 //     // Eigen::MatrixXd V = (X.transpose()*field2submesh*field2submesh.transpose()*X).inverse()*X.transpose()*field2submesh; // Ok
 //     // /// Define the full matrix to the full field
 //     // Eigen::MatrixXd Y = X*V;
-//     // //std::cout << "Y.rows() = " << Y.rows() << std::endl;
-//     // //std::cout << "Y.cols() = " << Y.cols() << std::endl;
+//     // //Info << "Y.rows() = " << Y.rows() << endl;
+//     // //Info << "Y.cols() = " << Y.cols() << endl;
 //     // train.EliObject->MatrixOnline = Y;
 
 //     // // PtrList<volVectorField> subfields;
@@ -432,7 +432,7 @@ void ScalarTransport::restart()
 //     // reduced.OnlineBurgers(NmodesUproj);
 
 //     // durationOn = (std::clock() - startOn);
-//     // std::cout << "The Online  phase  duration  is  equal  to " << durationOn << std::endl;
+//     // Info << "The Online  phase  duration  is  equal  to " << durationOn << endl;
 //     // //ITHACAstream::exportFields(reduced.Ufield, "./ITHACAoutput/Online", reduced.Ufield[0].name() );
 //     // //PtrList<volVectorField> errflds;
 //     // //exit(0);
@@ -501,15 +501,15 @@ void ScalarTransport::restart()
 // Info << x << endl;
 // //volVectorField x(xx);
 
-// std::cout << problem->EliObject->MatrixOnline.cols() << std::endl;
-// std::cout << problem->EliObject->MatrixOnline.rows() << std::endl;
+// Info << problem->EliObject->MatrixOnline.cols() << endl;
+// Info << problem->EliObject->MatrixOnline.rows() << endl;
 
 
 
 // Eigen::VectorXd y = Foam2Eigen::field2Eigen(x);
 
-// std::cout << y.cols() << std::endl;
-// std::cout << y.rows() << std::endl;
+// Info << y.cols() << endl;
+// Info << y.rows() << endl;
 
 //  exit(0);
 
@@ -538,8 +538,8 @@ void ScalarTransport::restart()
 // auto Ap = Q.transpose()* Ar *Q;
 // auto bp = Q.transpose() * br;
 
-//std::cout <<  "P = " << P << std::endl;
+//Info <<  "P = " << P << endl;
 
-//std::cout <<  "Ar = " << Q.transpose()* Ar *Q << std::endl;
-//std::cout <<  "br = " << Q.transpose() * br << std::endl;
+//Info <<  "Ar = " << Q.transpose()* Ar *Q << endl;
+//Info <<  "br = " << Q.transpose() * br << endl;
 //auto a = Ap.colPivHouseholderQr().solve(bp);

--- a/src/ITHACA_FOMPROBLEMS/SteadyNSSimple/SteadyNSSimple.C
+++ b/src/ITHACA_FOMPROBLEMS/SteadyNSSimple/SteadyNSSimple.C
@@ -88,7 +88,7 @@ void SteadyNSSimple::getTurbRBF(label NNutModes)
             ITHACAstream::ReadDenseMatrix(weights, "./ITHACAoutput/weights/", weightName);
             rbfSplines[i] = new SPLINTER::RBFSpline(* samples[i],
                                                     SPLINTER::RadialBasisFunctionType::GAUSSIAN, weights);
-            // std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+            // Info << "Constructing RadialBasisFunction for mode " << i + 1 << endl;
             Info << "Constructing RadialBasisFunction for mode " << i + 1 << endl;
         }
         else
@@ -105,7 +105,7 @@ void SteadyNSSimple::getTurbRBF(label NNutModes)
                                                     SPLINTER::RadialBasisFunctionType::GAUSSIAN);
             ITHACAstream::SaveDenseMatrix(rbfSplines[i]->weights,
                                           "./ITHACAoutput/weights/", weightName);
-            // std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+            // Info << "Constructing RadialBasisFunction for mode " << i + 1 << endl;
             Info << "Constructing RadialBasisFunction for mode " << i + 1 << endl;
         }
     }
@@ -242,8 +242,8 @@ void SteadyNSSimple::truthSolve2(List<scalar> mu_now, word Folder)
             ITHACAstream::exportSolution(p, name(folderN), Folder + name(counter));
             Ufield.append(U.clone());
             Pfield.append(p.clone());
-            res_U << uresidual << std::endl;
-            res_P << presidual << std::endl;
+            res_U << uresidual << endl;
+            res_P << presidual << endl;
 
             if (ITHACAutilities::isTurbulent())
             {
@@ -254,9 +254,9 @@ void SteadyNSSimple::truthSolve2(List<scalar> mu_now, word Folder)
         }
     }
 
-    snaps_os << folderN + 1 << std::endl;
-    iters << csolve << std::endl;
-    res_os << residual << std::endl;
+    snaps_os << folderN + 1 << endl;
+    iters << csolve << endl;
+    res_os << residual << endl;
     res_os.close();
     res_U.close();
     res_P.close();

--- a/src/ITHACA_FOMPROBLEMS/UnsteadyBB/UnsteadyBB.C
+++ b/src/ITHACA_FOMPROBLEMS/UnsteadyBB/UnsteadyBB.C
@@ -293,8 +293,8 @@ void UnsteadyBB::solvesupremizer(word type)
     }
     else
     {
-        std::cout << "You must specify the variable type with either snapshots or modes"
-                  << std::endl;
+        Info << "You must specify the variable type with either snapshots or modes"
+                  << endl;
         exit(0);
     }
 

--- a/src/ITHACA_FOMPROBLEMS/UnsteadyNSTTurb/UnsteadyNSTTurb.C
+++ b/src/ITHACA_FOMPROBLEMS/UnsteadyNSTTurb/UnsteadyNSTTurb.C
@@ -541,6 +541,6 @@ void UnsteadyNSTTurb::projectSUP(fileName folder, label NU, label NP,
 
         rbfsplines[i] = new SPLINTER::RBFSpline(* SAMPLES[i],
                                                 SPLINTER::RadialBasisFunctionType::GAUSSIAN);
-        std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+        Info << "Constructing RadialBasisFunction for mode " << i + 1 << endl;
     }
 }

--- a/src/ITHACA_FOMPROBLEMS/UnsteadyNSTurb/UnsteadyNSTurb.C
+++ b/src/ITHACA_FOMPROBLEMS/UnsteadyNSTurb/UnsteadyNSTurb.C
@@ -710,7 +710,7 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
                                 label Nnut,
                                 bool rbfInterp)
 {
-    std::cout << "[DEBUG] Entered projectSUP()" << std::endl;
+    Info << "[DEBUG] Entered projectSUP()" << endl;
     NUmodes   = NU;
     NPmodes   = NP;
     NSUPmodes = NSUP;
@@ -1084,24 +1084,24 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
         }
     }
 
-    std::cout << "[DEBUG] SUP sizes: cSize=" << cSize
+    Info << "[DEBUG] SUP sizes: cSize=" << cSize
               << ", NP=" << NPmodes << ", nNut=" << nNutModes << '\n';
-    std::cout << "[DEBUG] Shapes: M(" << M_matrix.rows() << "x" << M_matrix.cols()
+    Info << "[DEBUG] Shapes: M(" << M_matrix.rows() << "x" << M_matrix.cols()
               << ") B(" << B_matrix.rows() << "x" << B_matrix.cols()
               << ") bt(" << btMatrix.rows() << "x" << btMatrix.cols()
               << ") K(" << K_matrix.rows() << "x" << K_matrix.cols()
               << ") P(" << P_matrix.rows() << "x" << P_matrix.cols() << ")\n";
-    std::cout << "[DEBUG] projectSUP() done. SUP matrices/tensors exported.\n";
+    Info << "[DEBUG] projectSUP() done. SUP matrices/tensors exported.\n";
 
     if (rbfInterp && (!Pstream::parRun()))
     {
-        std::cout
+        Info
                 << "\n==== [RBF DEBUG SUP] ENTERING OFFLINE RBF CONSTRUCTION (AVG linear-μ + FLUCT RBF) ====\n";
         const word coeffDir = "./ITHACAoutput/Coefficients/";
         const word muPath   = "./ITHACAoutput/Offline/mu_samples_mat.txt";
         Eigen::MatrixXd muMat = ITHACAstream::readMatrix(muPath);
-        std::cout << "[RBF DEBUG SUP] muMat shape: " << muMat.rows() << " x " <<
-                  muMat.cols() << std::endl;
+        Info << "[RBF DEBUG SUP] muMat shape: " << muMat.rows() << " x " <<
+                  muMat.cols() << endl;
         const int nPar             = 12;
         const int nSnapshotsPerPar = 200;
         Eigen::VectorXd timeVec = muMat.col(0);
@@ -1110,10 +1110,10 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
                                             coeffDir + "Nut_avg_coeffs_mat.txt");
         Eigen::MatrixXd coeffNutFluct = ITHACAstream::readMatrix(
                                             coeffDir + "Nut_fluct_coeffs_mat.txt");
-        std::cout << "[RBF DEBUG SUP] Loaded coeffNutAvg shape: " << coeffNutAvg.rows()
-                  << " x " << coeffNutAvg.cols() << std::endl;
-        std::cout << "[RBF DEBUG SUP] Loaded coeffNutFluct shape: " <<
-                  coeffNutFluct.rows() << " x " << coeffNutFluct.cols() << std::endl;
+        Info << "[RBF DEBUG SUP] Loaded coeffNutAvg shape: " << coeffNutAvg.rows()
+                  << " x " << coeffNutAvg.cols() << endl;
+        Info << "[RBF DEBUG SUP] Loaded coeffNutFluct shape: " <<
+                  coeffNutFluct.rows() << " x " << coeffNutFluct.cols() << endl;
         const int nNutAvgModes   = coeffNutAvg.rows();
         const int nNutFluctModes = coeffNutFluct.rows();
         const int nUniqueMu      = nPar;
@@ -1127,8 +1127,8 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
             const int start = i * nSnapshotsPerPar;
             initSnapInd(i)  = start;
             timeSnap(i)     = timeVec(start + 1) - timeVec(start);
-            std::cout << "[RBF DEBUG SUP] i=" << i << ", start=" << start << ", dt=" <<
-                      timeSnap(i) << std::endl;
+            Info << "[RBF DEBUG SUP] i=" << i << ", start=" << start << ", dt=" <<
+                      timeSnap(i) << endl;
         }
 
         Eigen::VectorXd muVecUnique(nUniqueMu);
@@ -1138,20 +1138,20 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
             muVecUnique(i) = muVec(static_cast<int>(initSnapInd(i)));
         }
 
-        std::cout << "[RBF DEBUG SUP] muVecUnique: [" << muVecUnique(0) << " ... "
+        Info << "[RBF DEBUG SUP] muVecUnique: [" << muVecUnique(0) << " ... "
                   << muVecUnique(muVecUnique.size() - 1) << "] (M=" << muVecUnique.size() <<
                                                   ")\n";
-        std::cout <<
+        Info <<
         "[RBF DEBUG SUP] Calling velDerivativeCoeff() for fluctuation part...\n";
         Eigen::MatrixXd Gfluct = coeffNutFluct.transpose();
         List<Eigen::MatrixXd> interpDataFluct = velDerivativeCoeff(a, Gfluct,
                                                 initSnapInd, timeSnap);
         Eigen::MatrixXd velRBF_fluct = interpDataFluct[0];
         Eigen::MatrixXd coeffs_fluct = interpDataFluct[1];
-        std::cout << "[RBF DEBUG SUP] velRBF_fluct shape: " << velRBF_fluct.rows() <<
-                     " x " << velRBF_fluct.cols() << std::endl;
-        std::cout << "[RBF DEBUG SUP] coeffs_fluct shape: " << coeffs_fluct.rows() <<
-                     " x " << coeffs_fluct.cols() << std::endl;
+        Info << "[RBF DEBUG SUP] velRBF_fluct shape: " << velRBF_fluct.rows() <<
+                     " x " << velRBF_fluct.cols() << endl;
+        Info << "[RBF DEBUG SUP] coeffs_fluct shape: " << coeffs_fluct.rows() <<
+                     " x " << coeffs_fluct.cols() << endl;
         const int nSnapshots = velRBF_fluct.rows();
         const int nModes     = velRBF_fluct.cols() / 2;
         Eigen::MatrixXd adot_only(nSnapshots, nModes);
@@ -1201,7 +1201,7 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
         List<SPLINTER::RBFSpline*> rbfSplinesNutFluct;
         samplesNutFluct.resize(nNutFluctModes);
         rbfSplinesNutFluct.resize(nNutFluctModes);
-        std::cout << ">>> [SUP] Building nut_fluct RBF splines...\n";
+        Info << ">>> [SUP] Building nut_fluct RBF splines...\n";
 
         for (label i = 0; i < nNutFluctModes; ++i)
         {
@@ -1227,7 +1227,7 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
                     weights,
                     radiiFluct(i)
                 );
-                std::cout << "   [SUP] nut_fluct RBF " << i + 1 << "/" << nNutFluctModes
+                Info << "   [SUP] nut_fluct RBF " << i + 1 << "/" << nNutFluctModes
                           << " loaded from ./ITHACAoutput/weightsSUP/" << weightName << "\n";
             }
             else
@@ -1246,7 +1246,7 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
                     "./ITHACAoutput/weightsSUP/",
                     weightName
                 );
-                std::cout << "   [SUP] nut_fluct RBF " << i + 1 << "/" << nNutFluctModes
+                Info << "   [SUP] nut_fluct RBF " << i + 1 << "/" << nNutFluctModes
                           << " fitted & saved to ./ITHACAoutput/weightsSUP/" << weightName << "\n";
             }
         }
@@ -1255,7 +1255,7 @@ void UnsteadyNSTurb::projectSUP(fileName folder,
         this->rbfSplinesNutFluct = rbfSplinesNutFluct;
         this->samplesNutAvg      = samplesNutAvg;
         this->samplesNutFluct    = samplesNutFluct;
-        std::cout <<
+        Info <<
         ">>> [SUP] Finished AVG linear-μ table export + FLUCT RBF build.\n";
     }
 }
@@ -1883,13 +1883,13 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
 
     if (rbfInterp && (!Pstream::parRun()))
     {
-        std::cout
+        Info
                 << "\n==== [RBF DEBUG] ENTERING OFFLINE RBF CONSTRUCTION (AVG linear-μ + FLUCT RBF) ====\n";
         const word coeffDir = "./ITHACAoutput/Coefficients/";
         const word muPath   = "./ITHACAoutput/Offline/mu_samples_mat.txt";
         Eigen::MatrixXd muMat = ITHACAstream::readMatrix(muPath);
-        std::cout << "[RBF DEBUG] muMat shape: " << muMat.rows() << " x " <<
-                  muMat.cols() << std::endl;
+        Info << "[RBF DEBUG] muMat shape: " << muMat.rows() << " x " <<
+                  muMat.cols() << endl;
         const int nPar             = 12;
         const int nSnapshotsPerPar = 200;
         Eigen::VectorXd timeVec = muMat.col(0);
@@ -1898,10 +1898,10 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
                                             coeffDir + "Nut_avg_coeffs_mat.txt");
         Eigen::MatrixXd coeffNutFluct = ITHACAstream::readMatrix(
                                             coeffDir + "Nut_fluct_coeffs_mat.txt");
-        std::cout << "[RBF DEBUG] Loaded coeffNutAvg shape: " << coeffNutAvg.rows() <<
-                     " x " << coeffNutAvg.cols() << std::endl;
-        std::cout << "[RBF DEBUG] Loaded coeffNutFluct shape: " << coeffNutFluct.rows()
-                  << " x " << coeffNutFluct.cols() << std::endl;
+        Info << "[RBF DEBUG] Loaded coeffNutAvg shape: " << coeffNutAvg.rows() <<
+                     " x " << coeffNutAvg.cols() << endl;
+        Info << "[RBF DEBUG] Loaded coeffNutFluct shape: " << coeffNutFluct.rows()
+                  << " x " << coeffNutFluct.cols() << endl;
         const int nNutAvgModes   = coeffNutAvg.rows();
         const int nNutFluctModes = coeffNutFluct.rows();
         const int nUniqueMu      = nPar;
@@ -1915,8 +1915,8 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
             const int start = i * nSnapshotsPerPar;
             initSnapInd(i)  = start;
             timeSnap(i)     = timeVec(start + 1) - timeVec(start);
-            std::cout << "[RBF DEBUG] i=" << i << ", start=" << start << ", dt=" <<
-                      timeSnap(i) << std::endl;
+            Info << "[RBF DEBUG] i=" << i << ", start=" << start << ", dt=" <<
+                      timeSnap(i) << endl;
         }
 
         Eigen::VectorXd muVecUnique(nUniqueMu);
@@ -1926,20 +1926,20 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
             muVecUnique(i) = muVec(static_cast<int>(initSnapInd(i)));
         }
 
-        std::cout << "[RBF DEBUG] muVecUnique: [" << muVecUnique(0) << " ... "
+        Info << "[RBF DEBUG] muVecUnique: [" << muVecUnique(0) << " ... "
                   << muVecUnique(muVecUnique.size() - 1) << "] (M=" << muVecUnique.size() <<
                                                   ")\n";
-        std::cout <<
+        Info <<
         "[RBF DEBUG] Calling velDerivativeCoeff() for fluctuation part...\n";
         Eigen::MatrixXd Gfluct = coeffNutFluct.transpose();
         List<Eigen::MatrixXd> interpDataFluct = velDerivativeCoeff(a, Gfluct,
                                                 initSnapInd, timeSnap);
         Eigen::MatrixXd velRBF_fluct = interpDataFluct[0];
         Eigen::MatrixXd coeffs_fluct = interpDataFluct[1];
-        std::cout << "[RBF DEBUG] velRBF_fluct shape: " << velRBF_fluct.rows() << " x "
-                  << velRBF_fluct.cols() << std::endl;
-        std::cout << "[RBF DEBUG] coeffs_fluct shape: " << coeffs_fluct.rows() << " x "
-                  << coeffs_fluct.cols() << std::endl;
+        Info << "[RBF DEBUG] velRBF_fluct shape: " << velRBF_fluct.rows() << " x "
+                  << velRBF_fluct.cols() << endl;
+        Info << "[RBF DEBUG] coeffs_fluct shape: " << coeffs_fluct.rows() << " x "
+                  << coeffs_fluct.cols() << endl;
         const int nSnapshots = velRBF_fluct.rows();
         const int nModes     = velRBF_fluct.cols() / 2;
         Eigen::MatrixXd adot_only(nSnapshots, nModes);
@@ -1952,30 +1952,30 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
         ITHACAstream::exportMatrix(adot_only,    "adot_coeffs",   "python", coeffDir);
         ITHACAstream::exportMatrix(velRBF_fluct, "a_adot_concat", "python", coeffDir);
         ITHACAstream::exportMatrix(velRBF_fluct, "a_adot_concat", "eigen",  coeffDir);
-        std::cout << "\n[RBF DEBUG] First row of a (velocity coeffs): ";
+        Info << "\n[RBF DEBUG] First row of a (velocity coeffs): ";
 
         for (int k = 0; k < a.cols(); ++k)
         {
-            std::cout << a(0, k) << " ";
+            Info << a(0, k) << " ";
         }
 
-        std::cout << std::endl;
-        std::cout << "[RBF DEBUG] First row of velRBF_fluct ([a, aDot]): ";
+        Info << endl;
+        Info << "[RBF DEBUG] First row of velRBF_fluct ([a, aDot]): ";
 
         for (int k = 0; k < velRBF_fluct.cols(); ++k)
         {
-            std::cout << velRBF_fluct(0, k) << " ";
+            Info << velRBF_fluct(0, k) << " ";
         }
 
-        std::cout << std::endl;
-        std::cout << "[RBF DEBUG] First row of adot_only (aDot): ";
+        Info << endl;
+        Info << "[RBF DEBUG] First row of adot_only (aDot): ";
 
         for (int k = 0; k < adot_only.cols(); ++k)
         {
-            std::cout << adot_only(0, k) << " ";
+            Info << adot_only(0, k) << " ";
         }
 
-        std::cout << std::endl;
+        Info << endl;
         const double eAvg   = 3;
         const double eFluct = 0.05;
         Eigen::MatrixXd radiiAvg;
@@ -1984,30 +1984,30 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
         if (ITHACAutilities::check_file("./radii_avg.txt"))
         {
             radiiAvg = ITHACAstream::readMatrix("./radii_avg.txt");
-            std::cout << "[RBF DEBUG] Loaded radii_avg.txt, shape: " << radiiAvg.rows() <<
-                         " x " << radiiAvg.cols() << std::endl;
+            Info << "[RBF DEBUG] Loaded radii_avg.txt, shape: " << radiiAvg.rows() <<
+                         " x " << radiiAvg.cols() << endl;
             M_Assert(radiiAvg.size() == nNutAvgModes, "radiiAvg size mismatch");
         }
         else
         {
             radiiAvg = Eigen::MatrixXd::Ones(nNutAvgModes, 1) * eAvg;
-            std::cout <<
+            Info <<
             "[RBF DEBUG] Set default radii for nutAvg (unused with linear μ), e=" << eAvg
-                      << std::endl;
+                      << endl;
         }
 
         if (ITHACAutilities::check_file("./radii_fluct.txt"))
         {
             radiiFluct = ITHACAstream::readMatrix("./radii_fluct.txt");
-            std::cout << "[RBF DEBUG] Loaded radii_fluct.txt, shape: " << radiiFluct.rows()
-                      << " x " << radiiFluct.cols() << std::endl;
+            Info << "[RBF DEBUG] Loaded radii_fluct.txt, shape: " << radiiFluct.rows()
+                      << " x " << radiiFluct.cols() << endl;
             M_Assert(radiiFluct.size() == nNutFluctModes, "radiiFluct size mismatch");
         }
         else
         {
             radiiFluct = Eigen::MatrixXd::Ones(nNutFluctModes, 1) * eFluct;
-            std::cout << "[RBF DEBUG] Set default radii for nutFluct, e=" << eFluct <<
-                      std::endl;
+            Info << "[RBF DEBUG] Set default radii for nutFluct, e=" << eFluct <<
+                      endl;
         }
 
         List<SPLINTER::DataTable*> samplesNutAvg;
@@ -2018,14 +2018,14 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
                                    coeffDir);
         ITHACAstream::exportMatrix(coeffNutAvg, "NutAvg_coeffs_by_mu", "eigen",
                                    coeffDir);
-        std::cout << ">>> Persisted νt_avg tables for linear μ-interpolation: "
+        Info << ">>> Persisted νt_avg tables for linear μ-interpolation: "
                   << "mu size=" << muVecUnique.size()
                   << ", coeff table=" << coeffNutAvg.rows() << "x" << coeffNutAvg.cols() << "\n";
         List<SPLINTER::DataTable*> samplesNutFluct;
         List<SPLINTER::RBFSpline*> rbfSplinesNutFluct;
         samplesNutFluct.resize(nNutFluctModes);
         rbfSplinesNutFluct.resize(nNutFluctModes);
-        std::cout << ">>> Building nut_fluct RBF splines...\n";
+        Info << ">>> Building nut_fluct RBF splines...\n";
 
         for (label i = 0; i < nNutFluctModes; ++i)
         {
@@ -2051,7 +2051,7 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
                     weights,
                     radiiFluct(i)
                 );
-                std::cout << "   nut_fluct RBF " << i + 1 << "/" << nNutFluctModes
+                Info << "   nut_fluct RBF " << i + 1 << "/" << nNutFluctModes
                           << " loaded from weights.\n";
             }
             else
@@ -2070,24 +2070,24 @@ void UnsteadyNSTurb::projectPPE(fileName folder,
                     "./ITHACAoutput/weightsPPE/",
                     weightName
                 );
-                std::cout << "   nut_fluct RBF " << i + 1 << "/" << nNutFluctModes
+                Info << "   nut_fluct RBF " << i + 1 << "/" << nNutFluctModes
                           << " fitted & saved.\n";
             }
         }
 
-        std::cout << "[OFFLINE] Built nutAvgSplines:  "  << rbfSplinesNutAvg.size()
+        Info << "[OFFLINE] Built nutAvgSplines:  "  << rbfSplinesNutAvg.size()
                   << " (expected 0 for linear μ)\n";
-        std::cout << "[OFFLINE] Built nutFluctSplines:"  << rbfSplinesNutFluct.size() <<
-                  std::endl;
-        std::cout << ">>> Finished AVG linear-μ table export + FLUCT RBF build.\n";
+        Info << "[OFFLINE] Built nutFluctSplines:"  << rbfSplinesNutFluct.size() <<
+                  endl;
+        Info << ">>> Finished AVG linear-μ table export + FLUCT RBF build.\n";
         this->rbfSplinesNutAvg   = rbfSplinesNutAvg;
         this->rbfSplinesNutFluct = rbfSplinesNutFluct;
         this->samplesNutAvg      = samplesNutAvg;
         this->samplesNutFluct    = samplesNutFluct;
-        std::cout << "[OFFLINE] Built nutAvgSplines: "   << rbfSplinesNutAvg.size() <<
-                  std::endl;
-        std::cout << "[OFFLINE] Built nutFluctSplines: " << rbfSplinesNutFluct.size() <<
-                  std::endl;
+        Info << "[OFFLINE] Built nutAvgSplines: "   << rbfSplinesNutAvg.size() <<
+                  endl;
+        Info << "[OFFLINE] Built nutFluctSplines: " << rbfSplinesNutFluct.size() <<
+                  endl;
     }
 }
 
@@ -2146,19 +2146,19 @@ List<Eigen::MatrixXd> UnsteadyNSTurb::velParDerivativeCoeff(Eigen::MatrixXd A,
         Eigen::VectorXd initSnapInd,
         Eigen::VectorXd timeSnap)
 {
-    std::cout << "[velParDerivativeCoeff] ENTER" << std::endl;
+    Info << "[velParDerivativeCoeff] ENTER" << endl;
     List<Eigen::MatrixXd> newCoeffs;
     newCoeffs.setSize(2);
     const label velCoeffsNum           = A.cols();
     const label snapshotsNum           = A.rows();
     const label parsSamplesNum         = initSnapInd.size();
     const label timeSnapshotsPerSample = snapshotsNum / parsSamplesNum;
-    std::cout << "[velParDerivativeCoeff] A shape: " << snapshotsNum << " x " <<
-              velCoeffsNum << std::endl;
-    std::cout << "[velParDerivativeCoeff] G shape: " << G.rows() << " x " <<
-              G.cols() << std::endl;
-    std::cout << "[velParDerivativeCoeff] nPars: " << parsSamplesNum
-              << ", timeSnapshotsPerSample: " << timeSnapshotsPerSample << std::endl;
+    Info << "[velParDerivativeCoeff] A shape: " << snapshotsNum << " x " <<
+              velCoeffsNum << endl;
+    Info << "[velParDerivativeCoeff] G shape: " << G.rows() << " x " <<
+              G.cols() << endl;
+    Info << "[velParDerivativeCoeff] nPars: " << parsSamplesNum
+              << ", timeSnapshotsPerSample: " << timeSnapshotsPerSample << endl;
     Eigen::MatrixXd pars(snapshotsNum, 1);
 
     for (label j = 0; j < parsSamplesNum; ++j)
@@ -2169,10 +2169,10 @@ List<Eigen::MatrixXd> UnsteadyNSTurb::velParDerivativeCoeff(Eigen::MatrixXd A,
 
     const label newColsNum = 2 * velCoeffsNum;
     const label newRowsNum = snapshotsNum - parsSamplesNum;
-    std::cout << "[velParDerivativeCoeff] newCoeffs[0] size: " << newRowsNum <<
-                 " x " << (newColsNum + pars.cols()) << std::endl;
-    std::cout << "[velParDerivativeCoeff] newCoeffs[1] size: " << newRowsNum <<
-                 " x " << G.cols() << std::endl;
+    Info << "[velParDerivativeCoeff] newCoeffs[0] size: " << newRowsNum <<
+                 " x " << (newColsNum + pars.cols()) << endl;
+    Info << "[velParDerivativeCoeff] newCoeffs[1] size: " << newRowsNum <<
+                 " x " << G.cols() << endl;
     newCoeffs[0].resize(newRowsNum, newColsNum + pars.cols());
     newCoeffs[1].resize(newRowsNum, G.cols());
     int totalRowsWritten = 0;
@@ -2181,42 +2181,42 @@ List<Eigen::MatrixXd> UnsteadyNSTurb::velParDerivativeCoeff(Eigen::MatrixXd A,
     {
         const int start     = j * timeSnapshotsPerSample;
         const int rowOffset = j * (timeSnapshotsPerSample - 1);
-        std::cout << "[velParDerivativeCoeff] Group " << j
-                  << ": start=" << start << ", rowOffset=" << rowOffset << std::endl;
-        std::cout << "[velParDerivativeCoeff] b0: rows " << start << " to "
-                  << (start + timeSnapshotsPerSample - 2) << std::endl;
+        Info << "[velParDerivativeCoeff] Group " << j
+                  << ": start=" << start << ", rowOffset=" << rowOffset << endl;
+        Info << "[velParDerivativeCoeff] b0: rows " << start << " to "
+                  << (start + timeSnapshotsPerSample - 2) << endl;
 
         if (start + timeSnapshotsPerSample - 1 > snapshotsNum)
         {
             std::cerr << "[velParDerivativeCoeff][ERROR] b0 access out of bounds! (start="
                       << start << ", timeSnapshotsPerSample-1=" << (timeSnapshotsPerSample - 1)
-                      << ", snapshotsNum=" << snapshotsNum << ")" << std::endl;
+                      << ", snapshotsNum=" << snapshotsNum << ")" << endl;
             abort();
         }
 
         const Eigen::MatrixXd b0 = A.middleRows(start, timeSnapshotsPerSample - 1);
-        std::cout << "[velParDerivativeCoeff] b1: rows " << (start + 1) << " to "
-                  << (start + timeSnapshotsPerSample - 1) << std::endl;
+        Info << "[velParDerivativeCoeff] b1: rows " << (start + 1) << " to "
+                  << (start + timeSnapshotsPerSample - 1) << endl;
 
         if (start + 1 + timeSnapshotsPerSample - 2 >= snapshotsNum)
         {
             std::cerr << "[velParDerivativeCoeff][ERROR] b1 access out of bounds! (start+1="
                       << (start + 1) << ", timeSnapshotsPerSample-1=" << (timeSnapshotsPerSample - 1)
-                      << ", snapshotsNum=" << snapshotsNum << ")" << std::endl;
+                      << ", snapshotsNum=" << snapshotsNum << ")" << endl;
             abort();
         }
 
         const Eigen::MatrixXd b1 = A.middleRows(start + 1, timeSnapshotsPerSample - 1);
         Eigen::MatrixXd bNew(b0.rows(), b0.cols() + b1.cols());
         bNew << b1, (b1 - b0) / timeSnap(j);
-        std::cout << "[velParDerivativeCoeff] pars block for input: rows " <<
+        Info << "[velParDerivativeCoeff] pars block for input: rows " <<
                   (start + 1) << " to "
-                  << (start + timeSnapshotsPerSample - 1) << std::endl;
+                  << (start + timeSnapshotsPerSample - 1) << endl;
 
         if (start + 1 + timeSnapshotsPerSample - 2 >= snapshotsNum)
         {
             std::cerr << "[velParDerivativeCoeff][ERROR] pars access out of bounds!" <<
-                      std::endl;
+                      endl;
             abort();
         }
 
@@ -2224,26 +2224,26 @@ List<Eigen::MatrixXd> UnsteadyNSTurb::velParDerivativeCoeff(Eigen::MatrixXd A,
             pars.middleRows(start + 1, timeSnapshotsPerSample - 1);
         newCoeffs[0].block(rowOffset, pars.cols(), timeSnapshotsPerSample - 1,
                            newColsNum) = bNew;
-        std::cout << "[velParDerivativeCoeff] G block for output: rows " <<
+        Info << "[velParDerivativeCoeff] G block for output: rows " <<
                   (start + 1) << " to "
-                  << (start + timeSnapshotsPerSample - 1) << std::endl;
+                  << (start + timeSnapshotsPerSample - 1) << endl;
 
         if (start + 1 + timeSnapshotsPerSample - 2 >= G.rows())
         {
             std::cerr << "[velParDerivativeCoeff][ERROR] G access out of bounds!" <<
-                      std::endl;
+                      endl;
             abort();
         }
 
         newCoeffs[1].middleRows(rowOffset, timeSnapshotsPerSample - 1) =
             G.middleRows(start + 1, timeSnapshotsPerSample - 1);
         totalRowsWritten += timeSnapshotsPerSample - 1;
-        std::cout << "[velParDerivativeCoeff] Finished group " << j
-                  << ", totalRowsWritten so far: " << totalRowsWritten << std::endl;
+        Info << "[velParDerivativeCoeff] Finished group " << j
+                  << ", totalRowsWritten so far: " << totalRowsWritten << endl;
     }
 
-    std::cout << "[velParDerivativeCoeff] FINISHED. Total rows written: "
-              << totalRowsWritten << "/" << newRowsNum << std::endl;
+    Info << "[velParDerivativeCoeff] FINISHED. Total rows written: "
+              << totalRowsWritten << "/" << newRowsNum << endl;
     interChoice = 4;
     return newCoeffs;
 }

--- a/src/ITHACA_FOMPROBLEMS/inverseLaplacianProblemTotalHeatMeasure_paramBC/inverseLaplacianProblemTotalHeatMeasure_paramBC.C
+++ b/src/ITHACA_FOMPROBLEMS/inverseLaplacianProblemTotalHeatMeasure_paramBC/inverseLaplacianProblemTotalHeatMeasure_paramBC.C
@@ -67,12 +67,12 @@ void inverseLaplacianProblemTotalHeatMeasure_paramBC::parameterizedBCoffline(
             fin >> metaData.numberTC >> metaData.numberBasis >>
                 metaData.basisType >> metaData.shapeParameter;
             fin.close();
-            std::cout << "\nOffline FOUND with parameter:\n" <<
+            Info << "\nOffline FOUND with parameter:\n" <<
                          "Number of thermocouples = " << metaData.numberTC <<
                          "\nNumber of basis functions = " << metaData.numberBasis <<
                          "\nType of basis functions = " << metaData.basisType <<
                          "\nRBF shape parameters = " << metaData.shapeParameter <<
-                         "\n\nShould I recompute it? [y/n]" << std::endl;
+                         "\n\nShould I recompute it? [y/n]" << endl;
             std::cin >> recomputeOffline;
         }
         while (!cin.fail() && recomputeOffline != 'y' && recomputeOffline != 'n' );

--- a/src/ITHACA_FOMPROBLEMS/inverseLaplacianProblem_CG/inverseLaplacianProblem_CG.C
+++ b/src/ITHACA_FOMPROBLEMS/inverseLaplacianProblem_CG/inverseLaplacianProblem_CG.C
@@ -601,7 +601,7 @@ void inverseLaplacianProblem_CG::thermocouplesInterpolation()
         x(1) = interpolationPlane.thermocoupleZ[thermocoupleI];
         thermocouplesSamples.addSample(x, Tmeas(thermocoupleI));
     }
-    std::cout << Tmeas << std::endl;
+    Info << Tmeas << endl;
     RBFSpline rbfspline(thermocouplesSamples, RadialBasisFunctionType::GAUSSIAN);
     auto inPlaneCellID = 0;
     forAll(T.internalField(), cellI)
@@ -711,7 +711,7 @@ void inverseLaplacianProblem_CG::thermocouplesInterpolation(
         x(1) = interpolationPlane.thermocoupleZ[thermocoupleI];
         thermocouplesSamples.addSample(x, Tmeas(thermocoupleI));
     }
-    std::cout << Tmeas << std::endl;
+    Info << Tmeas << endl;
     RBFSpline rbfspline(thermocouplesSamples, RadialBasisFunctionType::GAUSSIAN);
     auto inPlaneCellID = 0;
     forAll(T.internalField(), cellI)

--- a/src/ITHACA_FOMPROBLEMS/inverseLaplacianProblem_paramBC/inverseLaplacianProblem_paramBC.C
+++ b/src/ITHACA_FOMPROBLEMS/inverseLaplacianProblem_paramBC/inverseLaplacianProblem_paramBC.C
@@ -212,12 +212,12 @@ void inverseLaplacianProblem_paramBC::parameterizedBCoffline(bool force)
             fin >> metaData.numberTC >> metaData.numberBasis >>
                 metaData.basisType >> metaData.shapeParameter;
             fin.close();
-            std::cout << "\nOffline FOUND with parameter:\n" <<
+            Info << "\nOffline FOUND with parameter:\n" <<
                          "Number of thermocouples = " << metaData.numberTC <<
                          "\nNumber of basis functions = " << metaData.numberBasis <<
                          "\nType of basis functions = " << metaData.basisType <<
                          "\nRBF shape parameters = " << metaData.shapeParameter <<
-                         "\n\nShould I recompute it? [y/n]" << std::endl;
+                         "\n\nShould I recompute it? [y/n]" << endl;
             std::cin >> recomputeOffline;
         }
         while (!cin.fail() && recomputeOffline != 'y' && recomputeOffline != 'n' );
@@ -368,19 +368,19 @@ void inverseLaplacianProblem_paramBC::parameterizedBCpostProcess(
     Eigen::VectorXd weigths)
 {
     //// Printing outputs at screen
-    //std::cout << "Eigenvalues of Theta.transpose() * Theta are " << std::endl;
-    //std::cout << linSys[0].eigenvalues() << std::endl;
+    //Info << "Eigenvalues of Theta.transpose() * Theta are " << endl;
+    //Info << linSys[0].eigenvalues() << endl;
     //Eigen::JacobiSVD<Eigen::MatrixXd> svd(linSys[0], Eigen::ComputeThinU | Eigen::ComputeThinV);
-    //std::cout << "Singular values of Theta.transpose() * Theta are " << std::endl;
-    //std::cout << svd.singularValues() << std::endl;
-    //std::cout << "debug: weigths size = " << std::endl;
-    //std::cout << weigths.size() << std::endl;
+    //Info << "Singular values of Theta.transpose() * Theta are " << endl;
+    //Info << svd.singularValues() << endl;
+    //Info << "debug: weigths size = " << endl;
+    //Info << weigths.size() << endl;
     //
     //residual =  linSys[0] * weigths - linSys[1];
-    //std::cout << "Residual  = " << std::endl;
-    //std::cout << residual << std::endl;
-    //std::cout << "Residual 2-norm = " << std::endl;
-    //std::cout << residual.squaredNorm() << std::endl;
+    //Info << "Residual  = " << endl;
+    //Info << residual << endl;
+    //Info << "Residual 2-norm = " << endl;
+    //Info << residual.squaredNorm() << endl;
     gWeights.resize(weigths.size());
     forAll(gWeights, weightI)
     {

--- a/src/ITHACA_FOMPROBLEMS/msrProblem/msrProblem.C
+++ b/src/ITHACA_FOMPROBLEMS/msrProblem/msrProblem.C
@@ -397,9 +397,9 @@ void msrProblem::projectPPE(fileName folder, label NU, label NP, label NF,
 {
     if (NPrec.size() != 8 || NDec.size() != 3)
     {
-        std::cout <<
+        Info <<
         "The model assumes 8 groups of precursors and 3 of decay heat, check NDrec and NDec dimensions..."
-                  << std::endl;
+                  << endl;
         exit(0);
     }
 
@@ -1775,7 +1775,7 @@ void msrProblem::readMSRfields(std::string& dir)
     }
     else
     {
-        std::cout << "Error" << std::endl;
+        Info << "Error" << endl;
     }
 }
 
@@ -1804,8 +1804,8 @@ void msrProblem::msrcoeff(label& NC)
 
     for (label i = 0; i < NCmodes; i++)
     {
-        std::cout << "Constructing v RadialBasisFunction for mode " << i + 1 <<
-                  std::endl;
+        Info << "Constructing v RadialBasisFunction for mode " << i + 1 <<
+                  endl;
         SAMPLES_v[i] = new SPLINTER::DataTable(1, 1);
 
         for (label j = 0; j < Ncol; j++)
@@ -1825,8 +1825,8 @@ void msrProblem::msrcoeff(label& NC)
 
     for (label i = 0; i < NCmodes; i++)
     {
-        std::cout << "Constructing D RadialBasisFunction for mode " << i + 1 <<
-                  std::endl;
+        Info << "Constructing D RadialBasisFunction for mode " << i + 1 <<
+                  endl;
         SAMPLES_D[i] = new SPLINTER::DataTable(1, 1);
 
         for (label j = 0; j < Ncol; j++)
@@ -1847,8 +1847,8 @@ void msrProblem::msrcoeff(label& NC)
 
     for (label i = 0; i < NCmodes; i++)
     {
-        std::cout << "Constructing NSF RadialBasisFunction for mode " << i + 1 <<
-                  std::endl;
+        Info << "Constructing NSF RadialBasisFunction for mode " << i + 1 <<
+                  endl;
         SAMPLES_NSF[i] = new SPLINTER::DataTable(1, 1);
 
         for (label j = 0; j < Ncol; j++)
@@ -1868,8 +1868,8 @@ void msrProblem::msrcoeff(label& NC)
 
     for (label i = 0; i < NCmodes; i++)
     {
-        std::cout << "Constructing A RadialBasisFunction for mode " << i + 1 <<
-                  std::endl;
+        Info << "Constructing A RadialBasisFunction for mode " << i + 1 <<
+                  endl;
         SAMPLES_A[i] = new SPLINTER::DataTable(1, 1);
 
         for (label j = 0; j < Ncol; j++)
@@ -1890,8 +1890,8 @@ void msrProblem::msrcoeff(label& NC)
 
     for (label i = 0; i < NCmodes; i++)
     {
-        std::cout << "Constructing  SP RadialBasisFunction for mode " << i + 1 <<
-                  std::endl;
+        Info << "Constructing  SP RadialBasisFunction for mode " << i + 1 <<
+                  endl;
         SAMPLES_SP[i] = new SPLINTER::DataTable(1, 1);
 
         for (label j = 0; j < Ncol; j++)
@@ -1912,8 +1912,8 @@ void msrProblem::msrcoeff(label& NC)
 
     for (label i = 0; i < NCmodes; i++)
     {
-        std::cout << "Constructing  TXS RadialBasisFunction for mode " << i + 1 <<
-                  std::endl;
+        Info << "Constructing  TXS RadialBasisFunction for mode " << i + 1 <<
+                  endl;
         SAMPLES_TXS[i] = new SPLINTER::DataTable(1, 1);
 
         for (label j = 0; j < Ncol; j++)

--- a/src/ITHACA_FOMPROBLEMS/reductionProblem/reductionProblem.C
+++ b/src/ITHACA_FOMPROBLEMS/reductionProblem/reductionProblem.C
@@ -340,9 +340,9 @@ std::vector<SPLINTER::RBFSpline> reductionProblem::getCoeffManifoldRBF(
         }
         else
         {
-            std::cout <<
+            Info <<
             "Unknown string for rbfBasis. Valid types are 'GAUSSIAN', 'THIN_PLATE', 'MULTI_QUADRIC', 'INVERSE_QUADRIC', 'INVERSE_MULTI_QUADRIC'"
-                      << std::endl;
+                      << endl;
             exit(0);
         }
     }
@@ -424,9 +424,9 @@ std::vector<SPLINTER::RBFSpline> reductionProblem::getCoeffManifoldRBF(
         }
         else
         {
-            std::cout <<
+            Info <<
             "Unknown string for rbfBasis. Valid types are 'GAUSSIAN', 'THIN_PLATE', 'MULTI_QUADRIC', 'INVERSE_QUADRIC', 'INVERSE_MULTI_QUADRIC'"
-                      << std::endl;
+                      << endl;
             exit(0);
         }
     }

--- a/src/ITHACA_FOMPROBLEMS/sequentialIHTP/sequentialIHTP.C
+++ b/src/ITHACA_FOMPROBLEMS/sequentialIHTP/sequentialIHTP.C
@@ -1207,31 +1207,31 @@ void sequentialIHTP::parameterizedBC_postProcess(
     if (verbose)
     {
         // Printing outputs at screen
-        std::cout << "Singular values of Theta.transpose() * Theta are " << std::endl;
-        std::cout << svd.singularValues() << std::endl;
-        std::cout << "weigths = " << std::endl;
-        std::cout << weigths << std::endl;
-        std::cout << "linSys[1] = " << std::endl;
-        std::cout << linSys[1] << std::endl;
-        std::cout << "Theta = " << std::endl;
-        std::cout << Theta << std::endl;
+        Info << "Singular values of Theta.transpose() * Theta are " << endl;
+        Info << svd.singularValues() << endl;
+        Info << "weigths = " << endl;
+        Info << weigths << endl;
+        Info << "linSys[1] = " << endl;
+        Info << linSys[1] << endl;
+        Info << "Theta = " << endl;
+        Info << Theta << endl;
         residual =  linSys[0] * weigths - linSys[1];
-        //std::cout << "Residual  = " << std::endl;
-        //std::cout << residual << std::endl;
-        std::cout << "Residual 2-norm = " << std::endl;
-        std::cout << residual.squaredNorm() << std::endl;
-        std::cout << "\n addSol = " << std::endl;
-        std::cout << addSol << std::endl;
-        std::cout << "T0_vector = " << std::endl;
-        std::cout << T0_vector << std::endl;
-        std::cout << "Tmeas = " << std::endl;
-        std::cout << Tmeas << std::endl;
+        //Info << "Residual  = " << endl;
+        //Info << residual << endl;
+        Info << "Residual 2-norm = " << endl;
+        Info << residual.squaredNorm() << endl;
+        Info << "\n addSol = " << endl;
+        Info << addSol << endl;
+        Info << "T0_vector = " << endl;
+        Info << T0_vector << endl;
+        Info << "Tmeas = " << endl;
+        Info << Tmeas << endl;
     }
 
     reconstrucT(outputFolder);
     Tcomp = fieldValueAtThermocouples(Ttime);
-    std::cout << "Tcomp = \n" << Tcomp.transpose() << std::endl;
-    std::cout << "TmeasShort = \n" << TmeasShort.transpose() << std::endl;
+    Info << "Tcomp = \n" << Tcomp.transpose() << endl;
+    Info << "TmeasShort = \n" << TmeasShort.transpose() << endl;
     J = 0.5 * Foam::sqrt((Tcomp - TmeasShort).dot(Tcomp - TmeasShort));
     Info << "J = " << J << endl;
     Jlist.conservativeResize(Jlist.size() + 1);

--- a/src/ITHACA_MUQ/Fang2017filter/Fang2017filter.C
+++ b/src/ITHACA_MUQ/Fang2017filter/Fang2017filter.C
@@ -321,9 +321,9 @@ void Fang2017filter::updateJointEns(Eigen::VectorXd _observation)
     //auto P_rank = lu_decomp.rank();
     //if (P_rank < P.cols() || P_rank < P.rows())
     //{
-    //    std::cout << "Pseudo inverse of P should be implemented in the EnKF, exiting" <<
-    //              std::endl;
-    //    std::cout << P << std::endl;
+    //    Info << "Pseudo inverse of P should be implemented in the EnKF, exiting" <<
+    //              endl;
+    //    Info << P << endl;
     //    exit(10);
     //}
     //else
@@ -385,19 +385,19 @@ void Fang2017filter::run(int innerLoopMax, word outputFolder)
                     sampleParameterDist();
                 }
 
-                std::cout << "\ndebug : parameterPriorMean = " <<
-                          parameterPriorMean << std::endl;
-                std::cout << "\ndebug : parameterMean.col(" << timeStepI << ") =\n" <<
-                          parameterMean.col(timeStepI) << std::endl;
+                Info << "\ndebug : parameterPriorMean = " <<
+                          parameterPriorMean << endl;
+                Info << "\ndebug : parameterMean.col(" << timeStepI << ") =\n" <<
+                          parameterMean.col(timeStepI) << endl;
             }
             else
             {
-                std::cout << "\ndebug : parameterMean before loop =\n" <<
-                          parameterMean.col(timeStepI) << std::endl;
+                Info << "\ndebug : parameterMean before loop =\n" <<
+                          parameterMean.col(timeStepI) << endl;
                 setParameterPriorDensity(parameterMean.col(timeStepI), parameterPriorCov);
                 sampleParameterDist();
-                std::cout << "\ndebug : parameterMean after loop =\n" <<
-                          parameterMean.col(timeStepI) << std::endl;
+                Info << "\ndebug : parameterMean after loop =\n" <<
+                          parameterMean.col(timeStepI) << endl;
             }
 
             stateProjection();
@@ -407,9 +407,9 @@ void Fang2017filter::run(int innerLoopMax, word outputFolder)
             {
                 Eigen::MatrixXd measNoiseSamps = ensembleFromDensity(measNoiseDensity);
                 observeState();
-                std::cout << "\ndebug : observation =\n" <<
+                Info << "\ndebug : observation =\n" <<
                           observations.col(observationBoolVec.head(timeStepI + 1).sum() - 1) <<
-                          std::endl;
+                          endl;
                 updateJointEns(
                     observations.col(
                         observationBoolVec.head(timeStepI + 1).sum() - 1));

--- a/src/ITHACA_MUQ/Fang2017filter_wDF/Fang2017filter_wDF.C
+++ b/src/ITHACA_MUQ/Fang2017filter_wDF/Fang2017filter_wDF.C
@@ -431,8 +431,7 @@ void Fang2017filter_wDF::run(int innerLoopMax, word outputFolder)
         if (timeStepI == 0)
         {
             setParameterPriorDensity(parameterPriorMean, parameterPriorCov);
-            std::cout << "debugInside: parameterPriorMean = " << parameterPriorMean <<
-                      std::endl;
+            Info << "debugInside: parameterPriorMean = " << parameterPriorMean << endl;
             sampleParameterDist();
         }
         else
@@ -451,14 +450,14 @@ void Fang2017filter_wDF::run(int innerLoopMax, word outputFolder)
             while (innerLoopI < innerLoopMax)
             {
                 Info << "Inner loop " << innerLoopI << endl;
-                std::cout << "debug: param mean =\n" << parameterEns.mean() << std::endl;
+                Info << "debug: param mean =\n" << parameterEns.mean() << endl;
 
                 if (innerLoopI > 0)
                 {
                     setParameterPriorDensity(parameterMean.col(timeStepI), parameterPriorCov);
                     sampleParameterDist();
-                    std::cout << "\ndebug : parameterMean after loop =\n" << parameterMean.col(
-                                  timeStepI) << std::endl;
+                    Info << "\ndebug : parameterMean after loop =\n" << parameterMean.col(
+                                  timeStepI) << endl;
                 }
 
                 buildJointEns();

--- a/src/ITHACA_MUQ/Pagani2016filter/Pagani2016filter.C
+++ b/src/ITHACA_MUQ/Pagani2016filter/Pagani2016filter.C
@@ -133,14 +133,14 @@ int Pagani2016filter::getObservationTimestep(int _timeSampleI)
 void Pagani2016filter::setTrueObservations(Eigen::MatrixXd _observations)
 {
     trueObservations = _observations;
-    std::cout << "trueObservations = \n" << trueObservations << std::endl;
+    Info << "trueObservations = \n" << trueObservations << endl;
 
     for (int colI = 0; colI < trueObservations.cols(); colI++)
     {
         trueObservations.col(colI) += measNoiseDensity->Sample();
     }
 
-    std::cout << "trueObservations w. error = \n" << trueObservations << std::endl;
+    Info << "trueObservations w. error = \n" << trueObservations << endl;
 }
 
 //--------------------------------------------------------------------------
@@ -343,9 +343,9 @@ void Pagani2016filter::update()
     Eigen::MatrixXd P = measNoiseDensity->ApplyCovariance(
                             Eigen::MatrixXd::Identity(observationSize, observationSize));
     P += observation_Cov;
-    std::cout << "debug : P = \n" << P << std::endl;
+    Info << "debug : P = \n" << P << endl;
     P = P.inverse(); //TODO check if invertible
-    std::cout << "debug : P inverse = \n" << P << std::endl;
+    Info << "debug : P inverse = \n" << P << endl;
     Eigen::MatrixXd parameterUpdateMat = parameterObservation_crossCov * P;
     Eigen::MatrixXd stateUpdateMat = stateObservation_crossCov * P;
 
@@ -359,9 +359,8 @@ void Pagani2016filter::update()
                               stateEns.getSample(seedI) + stateUpdateMat * observationDelta);
     }
 
-    std::cout << "debug : parameterEns.mean() =\n" << parameterEns.mean() <<
-              std::endl;
-    std::cout << "debug : stateEns.mean() =\n" << stateEns.mean() << std::endl;
+    Info << "debug : parameterEns.mean() =\n" << parameterEns.mean() << endl;
+    Info << "debug : stateEns.mean() =\n" << stateEns.mean() << endl;
 }
 
 //--------------------------------------------------------------------------

--- a/src/ITHACA_MUQ/muq2ithaca.C
+++ b/src/ITHACA_MUQ/muq2ithaca.C
@@ -42,9 +42,9 @@ Eigen::MatrixXd EnsembleKalmanFilter(Eigen::MatrixXd prior,
 
     if (P_rank < P.cols() || P_rank < P.rows())
     {
-        std::cout << "Pseudo inverse of P should be implemented in the EnKF, exiting" <<
-                  std::endl;
-        std::cout << P << std::endl;
+        Info << "Pseudo inverse of P should be implemented in the EnKF, exiting" <<
+                  endl;
+        Info << P << endl;
         exit(10);
     }
     else
@@ -60,8 +60,8 @@ Eigen::MatrixXd EnsembleKalmanFilter(Eigen::MatrixXd prior,
 
     if ((K.array() < 0.0).any())
     {
-        std::cout << "WARNING: Kalman Gain is negative.\nK = \n" << K << std::endl <<
-                  std::endl;
+        Info << "WARNING: Kalman Gain is negative.\nK = \n" << K << endl <<
+                  endl;
     }
 
     return prior + Z * M;
@@ -106,9 +106,9 @@ Eigen::MatrixXd EnsembleKalmanFilter(PtrList<volScalarField>& prior,
 
     if (P_rank < P.cols() || P_rank < P.rows())
     {
-        std::cout << "Pseudo inverse of P should be implemented in the EnKF, exiting" <<
-                  std::endl;
-        std::cout << P << std::endl;
+        Info << "Pseudo inverse of P should be implemented in the EnKF, exiting" <<
+                  endl;
+        Info << P << endl;
         exit(10);
     }
     else
@@ -124,8 +124,8 @@ Eigen::MatrixXd EnsembleKalmanFilter(PtrList<volScalarField>& prior,
 
     if ((K.array() < 0.0).any())
     {
-        std::cout << "WARNING: Kalman Gain is negative.\nK = \n" << K << std::endl <<
-                  std::endl;
+        Info << "WARNING: Kalman Gain is negative.\nK = \n" << K << endl <<
+                  endl;
     }
 
     return priorMatrix + Z * M;
@@ -176,7 +176,7 @@ double quantile(Eigen::VectorXd samps, double p, int method)
     }
     else
     {
-        std::cout << "Quantile method not implemented. Exiting." << std::endl;
+        Info << "Quantile method not implemented. Exiting." << endl;
         exit(10);
     }
 

--- a/src/ITHACA_ROMPROBLEMS/NonLinearSolvers/newton_argument.H
+++ b/src/ITHACA_ROMPROBLEMS/NonLinearSolvers/newton_argument.H
@@ -80,9 +80,9 @@ class newton_argument
         ///
         int operator()(const Eigen::VectorXd& x, Eigen::VectorXd& fvec) const
         {
-            std::cout <<
+            Info <<
             "This is a virtual method, it needs to be overriden with a suitable residual function"
-                      << std::endl;
+                      << endl;
             return 0;
         }
 
@@ -95,9 +95,9 @@ class newton_argument
         ///
         int df(const Eigen::VectorXd& x, Eigen::VectorXd& fvec) const
         {
-            std::cout <<
+            Info <<
             "This is a virtual method, it needs to be overriden with a suitable jacobian function"
-                      << std::endl;
+                      << endl;
             return 0;
         }
 

--- a/src/ITHACA_ROMPROBLEMS/ReducedCompressibleSteadyNS/ReducedCompressibleSteadyNS.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedCompressibleSteadyNS/ReducedCompressibleSteadyNS.C
@@ -162,28 +162,28 @@ void ReducedCompressibleSteadyNS::solveOnlineCompressible(scalar mu_now,
         );
         UEqnR.relax();
         fvOptions.constrain(UEqnR);
-        std::cout <<
+        Info <<
         "################################  line 165  ##############################" <<
-                  std::endl;
+                  endl;
         //RedLinSysU = ULmodes.project(problem->Ueqn_global(), NmodesUproj);
         RedLinSysU = problem->Umodes.project(UEqnR, NmodesUproj);
-        std::cout <<
+        Info <<
         "################################  line 169  ##############################" <<
-                  std::endl;
+                  endl;
         Eigen::MatrixXd projGradP = projGradModP * p;
-        std::cout <<
+        Info <<
         "################################  line 171  ##############################" <<
-                  std::endl;
+                  endl;
         RedLinSysU[1] = RedLinSysU[1] - projGradP;
         //u = reducedProblem::solveLinearSys(RedLinSysU, u, uResidual, vel_now, "bdcSvd");
         u = reducedProblem::solveLinearSys(RedLinSysU, u, uResidual);
-        std::cout <<
+        Info <<
         "################################  line 174  ##############################" <<
-                  std::endl;
+                  endl;
         problem->Umodes.reconstruct(U, u, "U");
-        std::cout <<
+        Info <<
         "################################  line 175  ##############################" <<
-                  std::endl;
+                  endl;
         //solve(problem->Ueqn_global() == -problem->getGradP(P)); //For debug purposes only, second part only useful when using uEqn_global==-getGradP
         //solve(UEqnR == -problem->getGradP(P)); //For debug purposes only, second part only useful when using uEqn_global==-getGradP
         fvOptions.correct(U);
@@ -202,14 +202,14 @@ void ReducedCompressibleSteadyNS::solveOnlineCompressible(scalar mu_now,
         // List<Eigen::MatrixXd> RedLinSysE = problem->Emodes.project(
         //                                        problem->Eeqn_global(), NmodesEproj);
         List<Eigen::MatrixXd> RedLinSysE = problem->Emodes.project(EEqnR, NmodesEproj);
-        std::cout <<
+        Info <<
         "################################  line 196  ##############################" <<
-                  std::endl;
+                  endl;
         e = reducedProblem::solveLinearSys(RedLinSysE, e, eResidual);
         problem->Emodes.reconstruct(E, e, "e");
-        std::cout <<
+        Info <<
         "################################  line 198  ##############################" <<
-                  std::endl;
+                  endl;
         //problem->Eeqn_global().solve(); //For debug purposes only
         //EEqnR.solve(); //For debug purposes only
         fvOptions.correct(E);
@@ -283,15 +283,15 @@ void ReducedCompressibleSteadyNS::solveOnlineCompressible(scalar mu_now,
 
         rho = thermo.rho(); // Here rho is calculated as p*psi = p/(R*T)
         rho.relax();
-        std::cout << "Ures = " << (uResidual.cwiseAbs()).sum() /
-                  (RedLinSysU[1].cwiseAbs()).sum() << std::endl;
-        std::cout << "Eres = " << (eResidual.cwiseAbs()).sum() /
-                  (RedLinSysE[1].cwiseAbs()).sum() << std::endl;
-        std::cout << "Pres = " << (pResidual.cwiseAbs()).sum() /
-                  (RedLinSysP[1].cwiseAbs()).sum() << std::endl;
-        // std::cout << "U = " << u << std::endl;
-        // std::cout << "E = " << e << std::endl;
-        // std::cout << "P = " << p << std::endl;
+        Info << "Ures = " << (uResidual.cwiseAbs()).sum() /
+                  (RedLinSysU[1].cwiseAbs()).sum() << endl;
+        Info << "Eres = " << (eResidual.cwiseAbs()).sum() /
+                  (RedLinSysE[1].cwiseAbs()).sum() << endl;
+        Info << "Pres = " << (pResidual.cwiseAbs()).sum() /
+                  (RedLinSysP[1].cwiseAbs()).sum() << endl;
+        // Info << "U = " << u << endl;
+        // Info << "E = " << e << endl;
+        // Info << "P = " << p << endl;
         residualNorm = max(max((uResidual.cwiseAbs()).sum() /
                                (RedLinSysU[1].cwiseAbs()).sum(),
                                (pResidual.cwiseAbs()).sum() / (RedLinSysP[1].cwiseAbs()).sum()),
@@ -302,8 +302,8 @@ void ReducedCompressibleSteadyNS::solveOnlineCompressible(scalar mu_now,
                                (RedLinSysP[1].cwiseAbs()).sum()),
                            ((eResidual - eResidualOld).cwiseAbs()).sum() /
                            (RedLinSysE[1].cwiseAbs()).sum());
-        std::cout << residualNorm << std::endl;
-        std::cout << residualJump << std::endl;
+        Info << residualNorm << endl;
+        Info << residualJump << endl;
         problem->turbulence->correct();
     }
 

--- a/src/ITHACA_ROMPROBLEMS/ReducedFsi/ReducedFsi.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedFsi/ReducedFsi.C
@@ -56,7 +56,7 @@ ReducedFsi::ReducedFsi(fsiBasic& FoamPb): problem(&FoamPb)
     }
 
     //problem->restart();
-    //std::cout << "################ ctor of POD-I Fsi ##################" << std::endl;
+    //Info << "################ ctor of POD-I Fsi ##################" << endl;
 }
 void ReducedFsi::PODI(Eigen::MatrixXd coeffL2, Eigen::MatrixXd muu,
                       label NPdModes)
@@ -87,7 +87,7 @@ void ReducedFsi::PODI(Eigen::MatrixXd coeffL2, Eigen::MatrixXd muu,
             ITHACAstream::ReadDenseMatrix(weights, "./ITHACAoutput/weights/", weightName);
             problem->rbfSplines[i] = new SPLINTER::RBFSpline(*(problem->samples)[i],
                 SPLINTER::RadialBasisFunctionType::THIN_PLATE_SPLINE, weights);
-            std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+            Info << "Constructing RadialBasisFunction for mode " << i + 1 << endl;
         }
         else
         {
@@ -103,7 +103,7 @@ void ReducedFsi::PODI(Eigen::MatrixXd coeffL2, Eigen::MatrixXd muu,
                 SPLINTER::RadialBasisFunctionType::THIN_PLATE_SPLINE);
             ITHACAstream::SaveDenseMatrix(problem->rbfSplines[i]->weights,
                                           "./ITHACAoutput/weights/", weightName);
-            std::cout << "Constructing RadialBasisFunction for mode " << i + 1 << std::endl;
+            Info << "Constructing RadialBasisFunction for mode " << i + 1 << endl;
         }
     }
 }
@@ -162,8 +162,8 @@ void ReducedFsi::solveOnline_Pimple(int NmodesUproj,
     Eigen::MatrixXd muEval(1, 1);
     //Eigen::VectorXd b_ref = Pmodes.project(p, NmodesPproj);
     //Eigen::VectorXd a_ref = Umodes.project(U, NmodesUproj);
-    //std::cout << " ==== b_ref === " << b_ref << std::endl;
-    //std::cout << " ==== a_ref === " << a_ref << std::endl;
+    //Info << " ==== b_ref === " << b_ref << endl;
+    //Info << " ==== a_ref === " << a_ref << endl;
     //exit(0);
     // double lambda0 = 1.0; // Initial weight
     // double lambda_t = 0.0;
@@ -181,8 +181,8 @@ void ReducedFsi::solveOnline_Pimple(int NmodesUproj,
         runTime++;
         //p.storePrevIter();
         Info << "Time = " << runTime.timeName() << nl << endl;
-        //res_u << runTime.timeName() << std::endl;
-        //res_p << runTime.timeName() << std::endl;
+        //res_u << runTime.timeName() << endl;
+        //res_p << runTime.timeName() << endl;
 
         while (pimple.loop())
         {
@@ -257,8 +257,8 @@ void ReducedFsi::solveOnline_Pimple(int NmodesUproj,
                 //Eigen::MatrixXd A_reg = RedLinSysU[0] + 1e-6 *Eigen::MatrixXd::Identity(NmodesUproj, NmodesUproj);
                 //a = A_reg.ldlt().solve(RedLinSysU[1]);
                 //Eigen::MatrixXd aNew = cg.solve(RedLinSysU[1]);
-                //std::cout << "res_u = " << (RedLinSysU[0] * a - RedLinSysU[1]).norm() << std::endl;
-                //res_u << (RedLinSysU[0] * a - RedLinSysU[1]).norm() << std::endl;
+                //Info << "res_u = " << (RedLinSysU[0] * a - RedLinSysU[1]).norm() << endl;
+                //res_u << (RedLinSysU[0] * a - RedLinSysU[1]).norm() << endl;
                 /*
                 if (cg.info() != Eigen::Success)
                 {
@@ -314,8 +314,8 @@ void ReducedFsi::solveOnline_Pimple(int NmodesUproj,
                     cgP.setTolerance(1e-6);
                     cgP.compute(RedLinSysP[0]);
                     Eigen::MatrixXd bNew = cgP.solve(RedLinSysP[1]);*/
-                    //std::cout << "res_p = " << (RedLinSysP[0] * b - RedLinSysP[1]).norm() << std::endl;
-                    //res_p << (RedLinSysP[0] * b - RedLinSysP[1]).norm() << std::endl;
+                    //Info << "res_p = " << (RedLinSysP[0] * b - RedLinSysP[1]).norm() << endl;
+                    //res_p << (RedLinSysP[0] * b - RedLinSysP[1]).norm() << endl;
                     Pmodes.reconstruct(p, b, "p");
 
                     //p.correctBoundaryConditions();

--- a/src/ITHACA_ROMPROBLEMS/ReducedMSR/ReducedMSR.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedMSR/ReducedMSR.C
@@ -619,46 +619,46 @@ void reducedMSR::solveOnline(Eigen::MatrixXd vel_now, Eigen::MatrixXd temp_now,
     newton_object_fd.operator()(y, res_fd);
     newton_object_n.operator()(w, res_n);
     newton_object_t.operator()(z, res_t);
-    std::cout << "################## Online solve N° " <<  count_online_solve <<
-              " ##################" << std::endl;
+    Info << "################## Online solve N° " <<  count_online_solve <<
+              " ##################" << endl;
 
     if (res_fd.norm() / y.norm() < 1e-5)
     {
-        std::cout << green << "|F_fd(x)| = " << res_fd.norm() / y.norm() <<
-                              " - Minimun reached in " << hnls_fd.iter << " iterations " << def << std::endl
-                  << std::endl;
+        Info << green << "|F_fd(x)| = " << res_fd.norm() / y.norm() <<
+                              " - Minimun reached in " << hnls_fd.iter << " iterations " << def << endl
+                  << endl;
     }
     else
     {
-        std::cout << red << "|F_fd(x)| = " << res_fd.norm() / y.norm() <<
-                            " - Minimun reached in " << hnls_fd.iter << " iterations " << def << std::endl
-                  << std::endl;
+        Info << red << "|F_fd(x)| = " << res_fd.norm() / y.norm() <<
+                            " - Minimun reached in " << hnls_fd.iter << " iterations " << def << endl
+                  << endl;
     }
 
     if (res_n.norm() / w.norm() < 1e-5)
     {
-        std::cout << green << "|F_n(x)| = " << res_n.norm() / w.norm() <<
-                              " - Minimun reached in " << hnls_n.iter << " iterations " << def << std::endl <<
-                  std::endl;
+        Info << green << "|F_n(x)| = " << res_n.norm() / w.norm() <<
+                              " - Minimun reached in " << hnls_n.iter << " iterations " << def << endl <<
+                  endl;
     }
     else
     {
-        std::cout << red << "|F_n(x)| = " << res_n.norm() / w.norm() <<
-                            " - Minimun reached in " << hnls_n.iter << " iterations " << def << std::endl <<
-                  std::endl;
+        Info << red << "|F_n(x)| = " << res_n.norm() / w.norm() <<
+                            " - Minimun reached in " << hnls_n.iter << " iterations " << def << endl <<
+                  endl;
     }
 
     if (res_t.norm() / z.norm() < 1e-5)
     {
-        std::cout << green << "|F_t(x)| = " << res_t.norm() / z.norm() <<
-                              " - Minimun reached in " << hnls_t.iter << " iterations " << def << std::endl <<
-                  std::endl;
+        Info << green << "|F_t(x)| = " << res_t.norm() / z.norm() <<
+                              " - Minimun reached in " << hnls_t.iter << " iterations " << def << endl <<
+                  endl;
     }
     else
     {
-        std::cout << red << "|F_t(x)| = " << res_t.norm() / z.norm() <<
-                            " - Minimun reached in " << hnls_t.iter << " iterations " << def << std::endl <<
-                  std::endl;
+        Info << red << "|F_t(x)| = " << res_t.norm() / z.norm() <<
+                            " - Minimun reached in " << hnls_t.iter << " iterations " << def << endl <<
+                  endl;
     }
 
     online_solution_fd[0](0, 0) = count_online_solve;

--- a/src/ITHACA_ROMPROBLEMS/ReducedSimpleSteadyNS/ReducedSimpleSteadyNS.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedSimpleSteadyNS/ReducedSimpleSteadyNS.C
@@ -168,7 +168,7 @@ void reducedSimpleSteadyNS::solveOnline_Simple(scalar mu_now,
             && iter < maxIterOn)
     {
         iter++;
-        std::cout << "Iteration " << iter << std::endl;
+        Info << "Iteration " << iter << endl;
 #if defined(OFVER) && (OFVER == 6)
         simple.loop(runTime);
 #else
@@ -235,18 +235,18 @@ void reducedSimpleSteadyNS::solveOnline_Simple(scalar mu_now,
 
         if (problem->para->debug)
         {
-            std::cout << "Residual jump = " << residual_jump << std::endl;
-            std::cout << "Normalized residual = " << std::max(U_norm_res,
-                      P_norm_res) << std::endl;
+            Info << "Residual jump = " << residual_jump << endl;
+            Info << "Normalized residual = " << std::max(U_norm_res,
+                      P_norm_res) << endl;
         }
     }
 
-    std::cout << "Solution " << counter << " converged in " << iter <<
-                 " iterations." << std::endl;
-    std::cout << "Final normalized residual for velocity: " << U_norm_res <<
-              std::endl;
-    std::cout << "Final normalized residual for pressure: " << P_norm_res <<
-              std::endl;
+    Info << "Solution " << counter << " converged in " << iter <<
+                 " iterations." << endl;
+    Info << "Final normalized residual for velocity: " << U_norm_res <<
+              endl;
+    Info << "Final normalized residual for pressure: " << P_norm_res <<
+              endl;
     ULmodes.reconstruct(U, a, "Uaux");
     P.rename("Paux");
     problem->Pmodes.reconstruct(P, b, "Paux");

--- a/src/ITHACA_ROMPROBLEMS/ReducedSteadyNS/ReducedSteadyNS.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedSteadyNS/ReducedSteadyNS.C
@@ -192,18 +192,18 @@ void reducedSteadyNS::solveOnline_sup(Eigen::MatrixXd vel)
 
     if (Pstream::master())
     {
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
     }
 
     if (res.norm() < 1e-5 && Pstream::master())
     {
-        std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                  hnls.iter << " iterations " << def << std::endl << std::endl;
+        Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                  hnls.iter << " iterations " << def << endl << endl;
     }
     else if (Pstream::master())
     {
-        std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                  hnls.iter << " iterations " << def << std::endl << std::endl;
+        Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                  hnls.iter << " iterations " << def << endl << endl;
     }
 
     count_online_solve += 1;

--- a/src/ITHACA_ROMPROBLEMS/ReducedSteadyNSTurb/ReducedSteadyNSTurb.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedSteadyNSTurb/ReducedSteadyNSTurb.C
@@ -256,19 +256,19 @@ void ReducedSteadyNSTurb::solveOnlineSUP(Eigen::MatrixXd vel)
     hnls.solve(y);
     Eigen::VectorXd res(y);
     newtonObjectSUP.operator()(y, res);
-    std::cout << "################## Online solve N° " << count_online_solve <<
-              " ##################" << std::endl;
-    std::cout << "Solving for the parameter: " << vel_now << std::endl;
+    Info << "################## Online solve N° " << count_online_solve <<
+              " ##################" << endl;
+    Info << "Solving for the parameter: " << vel_now << endl;
 
     if (res.norm() < 1e-5)
     {
-        std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                  hnls.iter << " iterations " << def << std::endl << std::endl;
+        Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                  hnls.iter << " iterations " << def << endl << endl;
     }
     else
     {
-        std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                  hnls.iter << " iterations " << def << std::endl << std::endl;
+        Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                  hnls.iter << " iterations " << def << endl << endl;
     }
 
     count_online_solve += 1;
@@ -321,19 +321,19 @@ void ReducedSteadyNSTurb::solveOnlinePPE(Eigen::MatrixXd vel)
     hnls.solve(y);
     Eigen::VectorXd res(y);
     newtonObjectPPE.operator()(y, res);
-    std::cout << "################## Online solve N° " << count_online_solve <<
-              " ##################" << std::endl;
-    std::cout << "Solving for the parameter: " << vel_now << std::endl;
+    Info << "################## Online solve N° " << count_online_solve <<
+              " ##################" << endl;
+    Info << "Solving for the parameter: " << vel_now << endl;
 
     if (res.norm() < 1e-5)
     {
-        std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                  hnls.iter << " iterations " << def << std::endl << std::endl;
+        Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                  hnls.iter << " iterations " << def << endl << endl;
     }
     else
     {
-        std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                  hnls.iter << " iterations " << def << std::endl << std::endl;
+        Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                  hnls.iter << " iterations " << def << endl << endl;
     }
 
     count_online_solve += 1;

--- a/src/ITHACA_ROMPROBLEMS/ReducedSteadyNSTurbIntrusive/ReducedSteadyNSTurbIntrusive.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedSteadyNSTurbIntrusive/ReducedSteadyNSTurbIntrusive.C
@@ -152,19 +152,19 @@ void ReducedSteadyNSTurbIntrusive::solveOnline(Eigen::MatrixXd vel)
     hnls.solve(y);
     Eigen::VectorXd res(y);
     newtonObject.operator()(y, res);
-    std::cout << "################## Online solve N° " << count_online_solve <<
-              " ##################" << std::endl;
-    std::cout << "Solving for the parameter: " << vel_now << std::endl;
+    Info << "################## Online solve N° " << count_online_solve <<
+              " ##################" << endl;
+    Info << "Solving for the parameter: " << vel_now << endl;
 
     if (res.norm() < 1e-5)
     {
-        std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                  hnls.iter << " iterations " << def << std::endl << std::endl;
+        Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                  hnls.iter << " iterations " << def << endl << endl;
     }
     else
     {
-        std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                  hnls.iter << " iterations " << def << std::endl << std::endl;
+        Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                  hnls.iter << " iterations " << def << endl << endl;
     }
 
     count_online_solve += 1;

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyBB/ReducedUnsteadyBB.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyBB/ReducedUnsteadyBB.C
@@ -252,9 +252,9 @@ int newton_unsteadyBB_PPE::df(const Eigen::VectorXd& x,
 Eigen::MatrixXd ReducedUnsteadyBB::solveOnline_sup(Eigen::MatrixXd& temp_now_BC,
         Eigen::MatrixXd& vel_now_BC, int NParaSet, int startSnap)
 {
-    std::cout << "################## Online solve N° " << NParaSet <<
-              " ##################" << std::endl;
-    std::cout << "Solving for the parameter: " << temp_now_BC << std::endl;
+    Info << "################## Online solve N° " << NParaSet <<
+              " ##################" << endl;
+    Info << "Solving for the parameter: " << temp_now_BC << endl;
     // Count number of time steps
     int counter = 0;
     time = tstart;
@@ -265,7 +265,7 @@ Eigen::MatrixXd ReducedUnsteadyBB::solveOnline_sup(Eigen::MatrixXd& temp_now_BC,
         counter ++;
     }
 
-    std::cerr << "File: ReducedUnsteadyBB.C, Line: 264" << std::endl;
+    std::cerr << "File: ReducedUnsteadyBB.C, Line: 264" << endl;
     // Set size of online solution
     online_solutiont.resize(Nphi_u + Nphi_prgh + Nphi_t + 1, counter + 1);
     // Set initial condition for online solve
@@ -279,7 +279,7 @@ Eigen::MatrixXd ReducedUnsteadyBB::solveOnline_sup(Eigen::MatrixXd& temp_now_BC,
             if (j == problem->inletIndexT(i, 0))
             {
                 T_IC.boundaryFieldRef()[problem->inletIndexT(i, 0)][j] = temp_now_BC(i, 0);
-                std::cerr << "File: ReducedUnsteadyBB.C, Line: 277" << std::endl;
+                std::cerr << "File: ReducedUnsteadyBB.C, Line: 277" << endl;
             }
             else
             {
@@ -287,7 +287,7 @@ Eigen::MatrixXd ReducedUnsteadyBB::solveOnline_sup(Eigen::MatrixXd& temp_now_BC,
         }
     }
 
-    std::cerr << "File: ReducedUnsteadyBB.C, Line: 284" << std::endl;
+    std::cerr << "File: ReducedUnsteadyBB.C, Line: 284" << endl;
     // Create and resize the solution vector
     y.resize(Nphi_u + Nphi_prgh + Nphi_t, 1);
     y.setZero();
@@ -302,9 +302,9 @@ Eigen::MatrixXd ReducedUnsteadyBB::solveOnline_sup(Eigen::MatrixXd& temp_now_BC,
                                             problem->Prghmodes);
     }
 
-    std::cerr << "File: ReducedUnsteadyBB.C, Line: 299" << std::endl;
+    std::cerr << "File: ReducedUnsteadyBB.C, Line: 299" << endl;
     y.tail(Nphi_t) = ITHACAutilities::getCoeffs(T_IC, LTmodes);
-    std::cerr << "File: ReducedUnsteadyBB.C, Line: 302" << std::endl;
+    std::cerr << "File: ReducedUnsteadyBB.C, Line: 302" << endl;
     // Set some properties of the newton object
     newton_object_sup.nu = nu;
     newton_object_sup.y_old = y;
@@ -363,13 +363,13 @@ Eigen::MatrixXd ReducedUnsteadyBB::solveOnline_sup(Eigen::MatrixXd& temp_now_BC,
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         tmp_sol(0) = time;
@@ -392,9 +392,9 @@ Eigen::MatrixXd ReducedUnsteadyBB::solveOnline_PPE(Eigen::MatrixXd&
         temp_now_BC,
         Eigen::MatrixXd& vel_now_BC, int NParaSet, int startSnap)
 {
-    std::cout << "################## Online solve N° " << NParaSet <<
-              " ##################" << std::endl;
-    std::cout << "Solving for the parameter: " << temp_now_BC << std::endl;
+    Info << "################## Online solve N° " << NParaSet <<
+              " ##################" << endl;
+    Info << "Solving for the parameter: " << temp_now_BC << endl;
     // Count number of time steps
     int counter = 0;
     time = tstart;
@@ -532,13 +532,13 @@ Eigen::MatrixXd ReducedUnsteadyBB::solveOnline_PPE(Eigen::MatrixXd&
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         tmp_sol(0) = time;

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyMSR/ReducedUnsteadyMSR.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyMSR/ReducedUnsteadyMSR.C
@@ -829,47 +829,47 @@ void reducedusMSR::solveOnline(Eigen::MatrixXd vel_now,
         newton_object_n.w_old = w;
         newton_object_t.operator()(z, res_t);
         newton_object_t.z_old = z;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
 
         if (res_fd.norm() / y.norm() < 1e-5)
         {
-            std::cout << green << "|F_fd(x)| = " << res_fd.norm() / y.norm() <<
-                                  " - Minimun reached in " << hnls_fd.iter << " iterations " << def << std::endl
-                      << std::endl;
+            Info << green << "|F_fd(x)| = " << res_fd.norm() / y.norm() <<
+                                  " - Minimun reached in " << hnls_fd.iter << " iterations " << def << endl
+                      << endl;
         }
         else
         {
-            std::cout << red << "|F_fd(x)| = " << res_fd.norm() / y.norm() <<
-                                " - Minimun reached in " << hnls_fd.iter << " iterations " << def << std::endl
-                      << std::endl;
+            Info << red << "|F_fd(x)| = " << res_fd.norm() / y.norm() <<
+                                " - Minimun reached in " << hnls_fd.iter << " iterations " << def << endl
+                      << endl;
         }
 
         if (res_n.norm() / w.norm() < 1e-5)
         {
-            std::cout << green << "|F_n(x)| = " << res_n.norm() / w.norm() <<
-                                  " - Minimun reached in " << hnls_n.iter << " iterations " << def << std::endl <<
-                      std::endl;
+            Info << green << "|F_n(x)| = " << res_n.norm() / w.norm() <<
+                                  " - Minimun reached in " << hnls_n.iter << " iterations " << def << endl <<
+                      endl;
         }
         else
         {
-            std::cout << red << "|F_n(x)| = " << res_n.norm() / w.norm() <<
-                                " - Minimun reached in " << hnls_n.iter << " iterations " << def << std::endl <<
-                      std::endl;
+            Info << red << "|F_n(x)| = " << res_n.norm() / w.norm() <<
+                                " - Minimun reached in " << hnls_n.iter << " iterations " << def << endl <<
+                      endl;
         }
 
         if (res_t.norm() / z.norm() < 1e-5)
         {
-            std::cout << green << "|F_t(x)| = " << res_t.norm() / z.norm() <<
-                                  " - Minimun reached in " << hnls_t.iter << " iterations " << def << std::endl <<
-                      std::endl;
+            Info << green << "|F_t(x)| = " << res_t.norm() / z.norm() <<
+                                  " - Minimun reached in " << hnls_t.iter << " iterations " << def << endl <<
+                      endl;
         }
         else
         {
-            std::cout << red << "|F_t(x)| = " << res_t.norm() / z.norm() <<
-                                " - Minimun reached in " << hnls_t.iter << " iterations " << def << std::endl <<
-                      std::endl;
+            Info << red << "|F_t(x)| = " << res_t.norm() / z.norm() <<
+                                " - Minimun reached in " << hnls_t.iter << " iterations " << def << endl <<
+                      endl;
         }
 
         count_online_solve += 1;

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNS/ReducedUnsteadyNS.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNS/ReducedUnsteadyNS.C
@@ -383,19 +383,19 @@ void reducedUnsteadyNS::solveOnline_sup(Eigen::MatrixXd vel,
         newton_object_sup.operator()(y, res);
         newton_object_sup.yOldOld = newton_object_sup.y_old;
         newton_object_sup.y_old = y;
-        std::cout << "################## Online solve N° " << counter <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << counter <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         tmp_sol(0) = time;
@@ -544,19 +544,19 @@ void reducedUnsteadyNS::solveOnline_PPE(Eigen::MatrixXd vel,
         newton_object_PPE.operator()(y, res);
         newton_object_PPE.yOldOld = newton_object_PPE.y_old;
         newton_object_PPE.y_old = y;
-        std::cout << "################## Online solve N° " << counter <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << counter <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         tmp_sol(0) = time;
@@ -611,8 +611,8 @@ Eigen::MatrixXd reducedUnsteadyNS::penalty_sup(Eigen::MatrixXd& vel_now,
             }
         }
 
-        std::cout << "Solving for penalty factor(s): " << tauIter << std::endl;
-        std::cout << "number of iterations: " << Iter << std::endl;
+        Info << "Solving for penalty factor(s): " << tauIter << endl;
+        Info << "number of iterations: " << Iter << endl;
         //  Set the old boundary value to the current value
         valBC0  = valBC;
         y.resize(Nphi_u + Nphi_p, 1);
@@ -668,13 +668,13 @@ Eigen::MatrixXd reducedUnsteadyNS::penalty_sup(Eigen::MatrixXd& vel_now,
 
             if (res.norm() < 1e-5)
             {
-                std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                          hnls.iter << " iterations " << def << std::endl << std::endl;
+                Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                          hnls.iter << " iterations " << def << endl << endl;
             }
             else
             {
-                std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                          hnls.iter << " iterations " << def << std::endl << std::endl;
+                Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                          hnls.iter << " iterations " << def << endl << endl;
             }
 
             volVectorField U_rec("U_rec", Umodes[0] * 0);
@@ -698,13 +698,13 @@ Eigen::MatrixXd reducedUnsteadyNS::penalty_sup(Eigen::MatrixXd& vel_now,
                              timeStepPenalty - 1)));
         }
 
-        std::cout << "max error: " << diffvel.maxCoeff() << std::endl;
+        Info << "max error: " << diffvel.maxCoeff() << endl;
         // Count the number of iterations
         Iter ++;
     }
 
-    std::cout << "Final penalty factor(s): " << tauIter << std::endl;
-    std::cout << "Iterations: " << Iter - 1 << std::endl;
+    Info << "Final penalty factor(s): " << tauIter << endl;
+    Info << "Iterations: " << Iter - 1 << endl;
     return tauIter;
 }
 
@@ -732,8 +732,8 @@ Eigen::MatrixXd reducedUnsteadyNS::penalty_PPE(Eigen::MatrixXd& vel_now,
             }
         }
 
-        std::cout << "Solving for penalty factor(s): " << tauIter << std::endl;
-        std::cout << "number of iterations: " << Iter << std::endl;
+        Info << "Solving for penalty factor(s): " << tauIter << endl;
+        Info << "number of iterations: " << Iter << endl;
         //  Set the old boundary value to the current value
         valBC0  = valBC;
         y.resize(Nphi_u + Nphi_p, 1);
@@ -791,13 +791,13 @@ Eigen::MatrixXd reducedUnsteadyNS::penalty_PPE(Eigen::MatrixXd& vel_now,
 
             if (res.norm() < 1e-5)
             {
-                std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                          hnls.iter << " iterations " << def << std::endl << std::endl;
+                Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                          hnls.iter << " iterations " << def << endl << endl;
             }
             else
             {
-                std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                          hnls.iter << " iterations " << def << std::endl << std::endl;
+                Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                          hnls.iter << " iterations " << def << endl << endl;
             }
 
             volVectorField U_rec("U_rec", Umodes[0] * 0);
@@ -821,13 +821,13 @@ Eigen::MatrixXd reducedUnsteadyNS::penalty_PPE(Eigen::MatrixXd& vel_now,
                              timeStepPenalty - 1)));
         }
 
-        std::cout << "max error: " << diffvel.maxCoeff() << std::endl;
+        Info << "max error: " << diffvel.maxCoeff() << endl;
         // Count the number of iterations
         Iter ++;
     }
 
-    std::cout << "Final penalty factor(s): " << tauIter << std::endl;
-    std::cout << "Iterations: " << Iter - 1 << std::endl;
+    Info << "Final penalty factor(s): " << tauIter << endl;
+    Info << "Iterations: " << Iter - 1 << endl;
     return tauIter;
 }
 

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSExplicit/ReducedUnsteadyNSExplicit.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSExplicit/ReducedUnsteadyNSExplicit.C
@@ -97,8 +97,8 @@ void ReducedUnsteadyNSExplicit::solveOnline(Eigen::MatrixXd vel,
         for (label i = 1; i < online_solution.size(); i++)
         {
             time = time + dt;
-            std::cout << " ################## time =   " << time <<
-                      " ##################" << std::endl;
+            Info << " ################## time =   " << time <<
+                      " ##################" << endl;
             // Pressure Poisson Equation
             // Diffusion Term
             Eigen::VectorXd M1 = problem->BP_matrix * a_o * nu ;
@@ -206,8 +206,8 @@ void ReducedUnsteadyNSExplicit::solveOnline(Eigen::MatrixXd vel,
         for (label i = 1; i < online_solution.size(); i++)
         {
             time = time + dt;
-            std::cout << " ################## time =   " << time <<
-                      " ##################" << std::endl;
+            Info << " ################## time =   " << time <<
+                      " ##################" << endl;
             Eigen::VectorXd presidual = Eigen::VectorXd::Zero(Nphi_p);
             // Pressure Poisson Equation
             // Diffusion Term
@@ -302,9 +302,9 @@ void ReducedUnsteadyNSExplicit::solveOnline(Eigen::MatrixXd vel,
     }
     else
     {
-        std::cout <<
+        Info <<
         "Only the inconsistent flux method and consistent flux method are implemented."
-                  << std::endl;
+                  << endl;
         exit(0);
     }
 }

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNST/ReducedUnsteadyNST.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNST/ReducedUnsteadyNST.C
@@ -292,32 +292,32 @@ void reducedUnsteadyNST::solveOnline_sup(Eigen::MatrixXd& vel_now,
         newton_object_sup.y_old = y;
         newton_object_sup_t.operator()(z, rest);
         newton_object_sup_t.z_old = z;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
-        std::cout << "Solving for the parameter: " << temp_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
+        Info << "Solving for the parameter: " << temp_now << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         if (rest.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << rest.norm() << " - Minimun reached in " <<
-                      hnlst.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << rest.norm() << " - Minimun reached in " <<
+                      hnlst.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << rest.norm() << " - Minimun reached in " <<
-                      hnlst.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << rest.norm() << " - Minimun reached in " <<
+                      hnlst.iter << " iterations " << def << endl << endl;
         }
 
         count_online_solve += 1;

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTTurb/ReducedUnsteadyNSTTurb.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTTurb/ReducedUnsteadyNSTTurb.C
@@ -127,7 +127,7 @@ int newton_unsteadyNSTTurb_sup::operator()(const Eigen::VectorXd& x,
     // Pressure Term
     Eigen::VectorXd M3 = problem->P_matrix * a_tmp;
 
-    //std::cerr << "I am here 5" << std::endl;
+    //std::cerr << "I am here 5" << endl;
     for (int i = 0; i < Nphi_u; i++)
     {
         cc = a_tmp.transpose() * problem->C_matrix[i] * a_tmp - nu_c.transpose() *
@@ -339,20 +339,20 @@ void ReducedUnsteadyNSTTurb::solveOnlineSup(Eigen::MatrixXd& vel_now,
         newton_object_sup.y_old = y;
         newton_object_sup_t.operator()(z, rest);
         newton_object_sup_t.z_old = z;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         count_online_solve += 1;

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurb/ReducedUnsteadyNSTurb.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurb/ReducedUnsteadyNSTurb.C
@@ -622,20 +622,20 @@ void ReducedUnsteadyNSTurb::solveOnlineSUP(Eigen::MatrixXd vel)
         newtonObjectSUP.operator()(y, res);
         newtonObjectSUP.yOldOld = newtonObjectSUP.y_old;
         newtonObjectSUP.y_old = y;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         count_online_solve += 1;
@@ -823,20 +823,20 @@ void ReducedUnsteadyNSTurb::solveOnlineSUPAve(Eigen::MatrixXd vel)
 
         newtonObjectSUPAve.yOldOld = newtonObjectSUPAve.y_old;
         newtonObjectSUPAve.y_old = y;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         count_online_solve += 1;
@@ -1015,20 +1015,20 @@ void ReducedUnsteadyNSTurb::solveOnlinePPE(Eigen::MatrixXd vel)
         newtonObjectPPE.operator()(y, res);
         newtonObjectPPE.yOldOld = newtonObjectPPE.y_old;
         newtonObjectPPE.y_old = y;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         count_online_solve += 1;
@@ -1216,20 +1216,20 @@ void ReducedUnsteadyNSTurb::solveOnlinePPEAve(Eigen::MatrixXd vel)
 
         newtonObjectPPEAve.yOldOld = newtonObjectPPEAve.y_old;
         newtonObjectPPEAve.y_old = y;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         count_online_solve += 1;

--- a/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurbIntrusive/ReducedUnsteadyNSTurbIntrusive.C
+++ b/src/ITHACA_ROMPROBLEMS/ReducedUnsteadyNSTurbIntrusive/ReducedUnsteadyNSTurbIntrusive.C
@@ -351,20 +351,20 @@ void ReducedUnsteadyNSTurbIntrusive::solveOnline(Eigen::MatrixXd vel)
         newtonObject.operator()(y, res);
         newtonObject.yOldOld = newtonObject.y_old;
         newtonObject.y_old = y;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         count_online_solve += 1;
@@ -499,20 +499,20 @@ void ReducedUnsteadyNSTurbIntrusive::solveOnlinePPE(Eigen::MatrixXd vel)
         newtonObjectPPE.operator()(y, res);
         newtonObjectPPE.yOldOld = newtonObjectPPE.y_old;
         newtonObjectPPE.y_old = y;
-        std::cout << "################## Online solve N° " << count_online_solve <<
-                  " ##################" << std::endl;
+        Info << "################## Online solve N° " << count_online_solve <<
+                  " ##################" << endl;
         Info << "Time = " << time << endl;
-        std::cout << "Solving for the parameter: " << vel_now << std::endl;
+        Info << "Solving for the parameter: " << vel_now << endl;
 
         if (res.norm() < 1e-5)
         {
-            std::cout << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << green << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
         else
         {
-            std::cout << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
-                      hnls.iter << " iterations " << def << std::endl << std::endl;
+            Info << red << "|F(x)| = " << res.norm() << " - Minimun reached in " <<
+                      hnls.iter << " iterations " << def << endl << endl;
         }
 
         count_online_solve += 1;

--- a/src/ITHACA_THIRD_PARTY/splinter/src/bsplinebuilder.C
+++ b/src/ITHACA_THIRD_PARTY/splinter/src/bsplinebuilder.C
@@ -14,6 +14,7 @@
 #include <serializer.h>
 #include <iostream>
 #include <utilities.h>
+#include "IOstreams.H"
 
 namespace SPLINTER
 {
@@ -126,9 +127,9 @@ DenseVector BSpline::Builder::computeCoefficients(const BSpline& bspline) const
     if (!solveAsDense)
     {
 #ifndef NDEBUG
-        std::cout <<
+        Foam::Info <<
         "BSpline::Builder::computeBSplineCoefficients: Computing B-spline control points using sparse solver."
-                  << std::endl;
+                  << Foam::endl;
 #endif // NDEBUG
         SparseLU<> s;
         //bool successfulSolve = (s.solve(A,Bx,Cx) && s.solve(A,By,Cy));
@@ -138,9 +139,9 @@ DenseVector BSpline::Builder::computeCoefficients(const BSpline& bspline) const
     if (solveAsDense)
     {
 #ifndef NDEBUG
-        std::cout <<
+        Foam::Info <<
         "BSpline::Builder::computeBSplineCoefficients: Computing B-spline control points using dense solver."
-                  << std::endl;
+                  << Foam::endl;
 #endif // NDEBUG
         DenseMatrix Ad = A.toDense();
         DenseQR<DenseVector> s;

--- a/src/ITHACA_THIRD_PARTY/splinter/src/datatable.C
+++ b/src/ITHACA_THIRD_PARTY/splinter/src/datatable.C
@@ -15,6 +15,7 @@
 #include <limits>
 #include <serializer.h>
 #include <initializer_list>
+#include "IOstreams.H"
 
 namespace SPLINTER
 {
@@ -81,9 +82,9 @@ void DataTable::addSample(const DataPoint& sample)
         if (!allowDuplicates)
         {
 #ifndef NDEBUG
-            std::cout << "Discarding duplicate sample because allowDuplicates is false!" <<
-                      std::endl;
-            std::cout << "Initialise with DataTable(true) to set it to true." << std::endl;
+            Foam::Info << "Discarding duplicate sample because allowDuplicates is false!" <<
+                      Foam::endl;
+            Foam::Info << "Initialise with DataTable(true) to set it to true." << Foam::endl;
 #endif // NDEBUG
             return;
         }

--- a/src/ITHACA_THIRD_PARTY/splinter/src/rbfspline.C
+++ b/src/ITHACA_THIRD_PARTY/splinter/src/rbfspline.C
@@ -11,6 +11,8 @@
 #include "rbfspline.h"
 #include "linearsolvers.h"
 #include <Eigen/Eigen>
+#include "IOstreams.H"
+#include "IOmanip.H"
 
 namespace SPLINTER
 {
@@ -175,8 +177,8 @@ RBFSpline::RBFSpline(const DataTable& samples, RadialBasisFunctionType type,
     }
 
 #ifndef NDEBUG
-    std::cout << "Computing RBF weights using dense solver." << std::endl;
-    std::cout << "The radius of the RBF is equal to " << e << std::endl;
+    Foam::Info << "Computing RBF weights using dense solver." << Foam::endl;
+    Foam::Info << "The radius of the RBF is equal to " << e << Foam::endl;
 #endif // NDEBUG
     // SVD analysis
     //         Eigen::JacobiSVD<DenseMatrix> svd(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
@@ -185,10 +187,10 @@ RBFSpline::RBFSpline(const DataTable& samples, RadialBasisFunctionType type,
     //         double svalmin = svals(svals.rows() - 1);
     //         double rcondnum = (svalmax <= 0.0 || svalmin <= 0.0) ? 0.0 : svalmin / svalmax;
     // #ifndef NDEBUG
-    //         std::cout << "The reciprocal of the condition number is: " << rcondnum <<
-    //         std::endl;
-    //         std::cout << "Largest/smallest singular value: " << svalmax << " / " << svalmin
-    //         << std::endl;
+    //         Info << "The reciprocal of the condition number is: " << rcondnum <<
+    //         endl;
+    //         Info << "Largest/smallest singular value: " << svalmax << " / " << svalmin
+    //         << endl;
     // #endif // NDEBUG
     //     // Solve for weights
     //         weights = svd.solve(b);
@@ -196,7 +198,7 @@ RBFSpline::RBFSpline(const DataTable& samples, RadialBasisFunctionType type,
 #ifndef NDEBUG
     // Compute error. If it is used later on, move this statement above the NDEBUG
     double err = (A * weights - b).norm() / b.norm();
-    std::cout << "Error: " << std::setprecision(10) << err << std::endl;
+    Foam::Info << "Error: " << Foam::setprecision(10) << err << Foam::endl;
 #endif // NDEBUG
     //    // Alternative solver
     //    DenseQR s;

--- a/tutorials/CFD/02thermalBlock/02thermalBlock.C
+++ b/tutorials/CFD/02thermalBlock/02thermalBlock.C
@@ -215,7 +215,7 @@ int main(int argc, char* argv[])
     {
         Info << "Pass 'offline' or 'online' as first arguments."
              << endl;
-        exit(0);
+        return 0;
     }
 
     // process arguments removing "offline" or "online" keywords
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     }
 
 #endif
-    exit(0);
+    return 0;
 }
 
 void offline_stage(tutorial02& example, tutorial02& FOM_test)

--- a/tutorials/CFD/03steadyNS/03steadyNS.C
+++ b/tutorials/CFD/03steadyNS/03steadyNS.C
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
     {
         Info << "Pass 'offline' or 'online' as first arguments."
              << endl;
-        exit(0);
+        return 0;
     }
 
     // process arguments removing "offline" or "online" keywords
@@ -161,7 +161,7 @@ int main(int argc, char* argv[])
     }
 
 #endif
-    exit(0);
+    return 0;
 }
 
 void offline_stage(tutorial03& example)

--- a/tutorials/CFD/04unsteadyNS/04unsteadyNS.C
+++ b/tutorials/CFD/04unsteadyNS/04unsteadyNS.C
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
     // Reconstruct the solution and export it
     reduced.reconstruct(true,
                         "./ITHACAoutput/Reconstruction" + example.method + "/");
-    exit(0);
+    return 0;
 }
 
 

--- a/tutorials/CFD/05PODI/05PODI.C
+++ b/tutorials/CFD/05PODI/05PODI.C
@@ -104,5 +104,5 @@ int main(int argc, char* argv[])
     ITHACAPOD::getModes(example.Pfield, example.Pmodes, example._p().name(),
                         example.podex, 0, 0,
                         NmodesPout);
-    exit(0);
+    return 0;
 }

--- a/tutorials/CFD/06POD_RBF/06POD_RBF.C
+++ b/tutorials/CFD/06POD_RBF/06POD_RBF.C
@@ -333,7 +333,7 @@ int main(int argc, char* argv[])
                                "./ITHACAoutput/ErrorsL2/");
     ITHACAstream::exportMatrix(errL2Nut, "errL2Nut", "matlab",
                                "./ITHACAoutput/ErrorsL2/");
-    exit(0);
+    return 0;
 }
 
 //--------

--- a/tutorials/CFD/07NonIsothermalMixingElbow/07NonIsothermalMixingElbow.C
+++ b/tutorials/CFD/07NonIsothermalMixingElbow/07NonIsothermalMixingElbow.C
@@ -161,6 +161,6 @@ int main(int argc, char* argv[])
     // Reconstruct the solution and export it
     reduced.reconstruct_sup("./ITHACAoutput/ReconstructionSUP/", 2);
     reduced.reconstruct_supt("./ITHACAoutput/ReconstructionSUP/", 2);
-    exit(0);
+    return 0;
 }
 

--- a/tutorials/CFD/09DEIM_ROM/09DEIM_ROM.C
+++ b/tutorials/CFD/09DEIM_ROM/09DEIM_ROM.C
@@ -284,16 +284,16 @@ int main(int argc, char* argv[])
     DEIMLaplacian example_new(argc, argv);
     example_new.OnlineSolveFull(par_new1, "Online_full");
     // Output some infos
-    std::cout << std::endl << "The FOM Solve took: " << example_new.time_full  <<
-                              " seconds." << std::endl;
-    std::cout << std::endl << "The ROM Solve took: " << example.time_rom  <<
-                              " seconds." << std::endl;
-    std::cout << std::endl << "The Speed-up is: " << example_new.time_full /
-              example.time_rom  << std::endl << std::endl;
+    Info << endl << "The FOM Solve took: " << example_new.time_full  <<
+                              " seconds." << endl;
+    Info << endl << "The ROM Solve took: " << example.time_rom  <<
+                              " seconds." << endl;
+    Info << endl << "The Speed-up is: " << example_new.time_full /
+              example.time_rom  << endl << endl;
     Eigen::MatrixXd error = ITHACAutilities::errorL2Abs(example_new.Tfield,
                             example.Tonline);
-    std::cout << "The mean L2 error is: " << error.mean() << std::endl;
-    exit(0);
+    Info << "The mean L2 error is: " << error.mean() << endl;
+    return 0;
 }
 
 /// \dir 09DEIM_ROM Folder of the turorial 9

--- a/tutorials/CFD/10unsteadyBB_enclosed/10UnsteadyBBEnclosed.C
+++ b/tutorials/CFD/10unsteadyBB_enclosed/10UnsteadyBBEnclosed.C
@@ -355,7 +355,7 @@ int main(int argc, char* argv[])
                                "./ITHACAoutput/l2error");
     ITHACAstream::exportMatrix(L2errorMatrixT, "L2errorMatrixT", "eigen",
                                "./ITHACAoutput/l2error");
-    exit(0);
+    return 0;
 }
 
 /// \dir 10unsteadyBB_open Folder of the tutorial 10

--- a/tutorials/CFD/11UnsteadyBBOpen/11UnsteadyBBOpen.C
+++ b/tutorials/CFD/11UnsteadyBBOpen/11UnsteadyBBOpen.C
@@ -426,7 +426,7 @@ int main(int argc, char* argv[])
                                "./ITHACAoutput/l2error");
     ITHACAstream::exportMatrix(L2errorMatrixT, "L2errorMatrixT", "eigen",
                                "./ITHACAoutput/l2error");
-    exit(0);
+    return 0;
 }
 
 /// \dir 11UnsteadyBB Folder of the turorial 11

--- a/tutorials/CFD/12simpleSteadyNS/12simpleSteadyNS.C
+++ b/tutorials/CFD/12simpleSteadyNS/12simpleSteadyNS.C
@@ -132,5 +132,5 @@ int main(int argc, char* argv[])
         reduced.solveOnline_Simple(mu_now, NmodesUproj, NmodesPproj);
     }
 
-    exit(0);
+    return 0;
 }

--- a/tutorials/CFD/15MSR_cavity/15MSR_cavity.C
+++ b/tutorials/CFD/15MSR_cavity/15MSR_cavity.C
@@ -241,7 +241,7 @@ int main(int argc, char* argv[])
         std::ofstream diff_t("./ITHACAoutput/t_offline=" + name(deltat_offline));
     }
 
-    std::cout << "Offline stage time= " << deltat_offline << std::endl;
+    Info << "Offline stage time= " << deltat_offline << endl;
     //compute the liftfunction for the velocity
     prova.liftSolve();
     //compute the liftfuncion for the temperature
@@ -318,7 +318,7 @@ int main(int argc, char* argv[])
     Eigen::MatrixXd PtotFOM(prova.Tnumber, tf);
     Eigen::MatrixXd TmROM(prova.Tnumber, tf);
     Eigen::MatrixXd PtotROM(prova.Tnumber, tf);
-    std::cout << "Computing errors on reference case..." << std::endl;
+    Info << "Computing errors on reference case..." << endl;
 
     for (int i = ref_start; i < ref_start + tf; i++)
     {
@@ -343,10 +343,10 @@ int main(int argc, char* argv[])
         c++;
     }
 
-    std::cout << "End" << std::endl;
+    Info << "End" << endl;
     ITHACAstream::exportMatrix(err, "err", "eigen",
                                "./ITHACAoutput");
-    std::cout << "computing FOM output..." << std::endl;
+    Info << "computing FOM output..." << endl;
     double tmpt;
     double tmpp;
     int rig = 0;
@@ -374,7 +374,7 @@ int main(int argc, char* argv[])
         }
     }
 
-    std::cout << "End" << std::endl;
+    Info << "End" << endl;
     ITHACAstream::exportMatrix(TmFOM, "fom_resT", "eigen",
                                "./ITHACAoutput");
     ITHACAstream::exportMatrix(PtotFOM, "fom_resP", "eigen",
@@ -493,17 +493,17 @@ int main(int argc, char* argv[])
     analisi.load_output();
     //compute output statistics
     analisi.getYstat();
-    std::cout << "Mean value and variance of the output:" << std::endl;
-    std::cout << analisi.Ey << "\t" << analisi.Vy << std::endl;
-    std::cout << "-------------" << std::endl;
+    Info << "Mean value and variance of the output:" << endl;
+    Info << analisi.Ey << "\t" << analisi.Vy << endl;
+    Info << "-------------" << endl;
     // compute linear regression coefficients
     analisi.getBetas();
-    std::cout << "analisi regression coefficients:" << std::endl;
-    std::cout << analisi.betas << std::endl;
-    std::cout << "-------------" << std::endl;
+    Info << "analisi regression coefficients:" << endl;
+    Info << analisi.betas << endl;
+    Info << "-------------" << endl;
     // assess the quality of the linear regression, i.e. R^2
     analisi.assessQuality();
-    std::cout << "quality: " << analisi.QI << std::endl;
+    Info << "quality: " << analisi.QI << endl;
     // save the ROM output, linear output, statistics
     Eigen::MatrixXd saveyout(samplingPoints, 1);
     Eigen::MatrixXd saveymodel(samplingPoints, 1);
@@ -526,15 +526,15 @@ int main(int argc, char* argv[])
     // for the total power
     analisi.load_output();
     analisi.getYstat();
-    std::cout << "Mean value and variance of the output:" << std::endl;
-    std::cout << analisi.Ey << "\t" << analisi.Vy << std::endl;
-    std::cout << "-------------" << std::endl;
+    Info << "Mean value and variance of the output:" << endl;
+    Info << analisi.Ey << "\t" << analisi.Vy << endl;
+    Info << "-------------" << endl;
     analisi.getBetas();
-    std::cout << "analisi regression coefficients:" << std::endl;
-    std::cout << analisi.betas << std::endl;
-    std::cout << "-------------" << std::endl;
+    Info << "analisi regression coefficients:" << endl;
+    Info << analisi.betas << endl;
+    Info << "-------------" << endl;
     analisi.assessQuality();
-    std::cout << "quality: " << analisi.QI << std::endl;
+    Info << "quality: " << analisi.QI << endl;
     Eigen::MatrixXd saveyoutP(samplingPoints, 1);
     Eigen::MatrixXd saveymodelP(samplingPoints, 1);
     saveyoutP.col(0) = analisi.y;

--- a/tutorials/CFD/16MSR_FOMSA/16MSR_FOMSA.C
+++ b/tutorials/CFD/16MSR_FOMSA/16MSR_FOMSA.C
@@ -205,7 +205,7 @@ int main(int argc, char* argv[])
         std::ofstream diff_t("./ITHACAoutput/t_SA=" + name(deltat_offline));
     }
 
-    std::cout << "Offline stage time= " << deltat_offline << std::endl;
+    Info << "Offline stage time= " << deltat_offline << endl;
     //sensitivity analysis
     int Nparameters = prova.Pnumber;
     int samplingPoints = prova.Tnumber;
@@ -226,15 +226,15 @@ int main(int argc, char* argv[])
     //load the model output in the VDSensitivity object
     analisi.load_output();
     analisi.getYstat();
-    std::cout << "Mean value and variance of the output:" << std::endl;
-    std::cout << analisi.Ey << "\t" << analisi.Vy << std::endl;
-    std::cout << "-------------" << std::endl;
+    Info << "Mean value and variance of the output:" << endl;
+    Info << analisi.Ey << "\t" << analisi.Vy << endl;
+    Info << "-------------" << endl;
     analisi.getBetas();
-    std::cout << "analisi regression coefficients:" << std::endl;
-    std::cout << analisi.betas << std::endl;
-    std::cout << "-------------" << std::endl;
+    Info << "analisi regression coefficients:" << endl;
+    Info << analisi.betas << endl;
+    Info << "-------------" << endl;
     analisi.assessQuality();
-    std::cout << "quality: " << analisi.QI << std::endl;
+    Info << "quality: " << analisi.QI << endl;
     Eigen::MatrixXd saveyout(samplingPoints, 1);
     Eigen::MatrixXd saveymodel(samplingPoints, 1);
     saveyout.col(0) = analisi.y;
@@ -255,15 +255,15 @@ int main(int argc, char* argv[])
     //load the model output in the VDSensitivity object
     analisi.load_output();
     analisi.getYstat();
-    std::cout << "Mean value and variance of the output:" << std::endl;
-    std::cout << analisi.Ey << "\t" << analisi.Vy << std::endl;
-    std::cout << "-------------" << std::endl;
+    Info << "Mean value and variance of the output:" << endl;
+    Info << analisi.Ey << "\t" << analisi.Vy << endl;
+    Info << "-------------" << endl;
     analisi.getBetas();
-    std::cout << "analisi regression coefficients:" << std::endl;
-    std::cout << analisi.betas << std::endl;
-    std::cout << "-------------" << std::endl;
+    Info << "analisi regression coefficients:" << endl;
+    Info << analisi.betas << endl;
+    Info << "-------------" << endl;
     analisi.assessQuality();
-    std::cout << "quality: " << analisi.QI << std::endl;
+    Info << "quality: " << analisi.QI << endl;
     Eigen::MatrixXd saveyoutP(samplingPoints, 1);
     Eigen::MatrixXd saveymodelP(samplingPoints, 1);
     saveyoutP.col(0) = analisi.y;

--- a/tutorials/CFD/17YJunction/17YJunction.C
+++ b/tutorials/CFD/17YJunction/17YJunction.C
@@ -317,7 +317,7 @@ int main(int argc, char* argv[])
     // Set the online temperature BC and solve reduced model
     reduced.solveOnline_PPE(vel_now);
     reduced.reconstruct(false, "./ITHACAoutput/Reconstruction/");
-    exit(0);
+    return 0;
 }
 
 /// \dir 17YJunction Folder of the turorial 17

--- a/tutorials/CFD/18simpleTurbNS/18simpleTurbNS.C
+++ b/tutorials/CFD/18simpleTurbNS/18simpleTurbNS.C
@@ -187,5 +187,5 @@ int main(int argc, char* argv[])
         }
     }
 
-    exit(0);
+    return 0;
 }

--- a/tutorials/CFD/19UnsteadyNSExplicit/19UnsteadyNSExplicit.C
+++ b/tutorials/CFD/19UnsteadyNSExplicit/19UnsteadyNSExplicit.C
@@ -148,7 +148,7 @@ int main(int argc, char* argv[])
     reduced.solveOnline(vel_now, 1);
     // Reconstruct the solution and export it
     reduced.reconstruct(false, "./ITHACAoutput/Reconstruction/");
-    exit(0);
+    return 0;
 }
 
 /// \dir 19UnsteadyNSExplicit Folder of the turorial 19

--- a/tutorials/CFD/21unsteadyNSTurb_RBF/21unsteadyNSTurb_RBF.C
+++ b/tutorials/CFD/21unsteadyNSTurb_RBF/21unsteadyNSTurb_RBF.C
@@ -247,5 +247,5 @@ int main(int argc, char* argv[])
                                "./ITHACAoutput/ErrorsL2/");
     ITHACAstream::exportMatrix(errL2Nut, "errL2Nut", "matlab",
                                "./ITHACAoutput/ErrorsL2/");
-    exit(0);
+    return 0;
 }

--- a/tutorials/CFD/22datadriven_corrections/offline.C
+++ b/tutorials/CFD/22datadriven_corrections/offline.C
@@ -136,9 +136,9 @@ int main(int argc, char* argv[])
 {
     if (argc == 1)
     {
-        std::cout << "Pass 'supremizer' or 'poisson' as first arguments."
-                  << std::endl;
-        exit(0);
+        Info << "Pass 'supremizer' or 'poisson' as first arguments."
+                  << endl;
+        return 0;
     }
 
     // process arguments removing "offline" or "online" keywords
@@ -165,10 +165,10 @@ int main(int argc, char* argv[])
     }
     else
     {
-        std::cout << "Pass supremizer, poisson" << std::endl;
+        Info << "Pass supremizer, poisson" << endl;
     }
 
-    exit(0);
+    return 0;
 }
 
 void supremizer_approach(tutorial22& example)

--- a/tutorials/CFD/25Moving_Cylinder/Moving_Cylinder.C
+++ b/tutorials/CFD/25Moving_Cylinder/Moving_Cylinder.C
@@ -77,7 +77,7 @@ class tutorial22: public fsiBasic
                     //std::clock_t startOff;
                     //startOff = std::clock();
                     //folderN = i;
-                    std::cout << "Current mu = " << mu(i, 0) << std::endl;
+                    Info << "Current mu = " << mu(i, 0) << endl;
                     //change_viscosity(mu(i, 0));
                     //change_stiffness(mu(i,0));
                     //meshPtr().movePoints(Mesh0->points());
@@ -144,9 +144,9 @@ int main(int argc, char* argv[])
     //startOff= std::clock();
     //Info << example.Mesh0->checkMesh(true) << endl;
     //exit(0);
-    //std::cerr << "debug point 3" << std::endl;
+    //std::cerr << "debug point 3" << endl;
     example.offlineSolve();
-    //std::cerr << "debug point 4" << std::endl;
+    //std::cerr << "debug point 4" << endl;
     //example.meshPtr().movePoints( example.Mesh0->points());
 
     // bool meshesDiffer = false;
@@ -170,7 +170,7 @@ int main(int argc, char* argv[])
     //     Info << "Meshes differ in point locations." << endl;
     // else
     // Info << "Meshes are geometrically identical." << endl;
-    // //std::cout << "The Offline phase  duration  is  equal  to " << durationOff << std::endl;
+    // //Info << "The Offline phase  duration  is  equal  to " << durationOff << endl;
     // exit(0);
 
     //example.meshPtr().movePoints(example.Dfield[0]);
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
 
         for (label k = 0; k < parsOn.rows(); k++)
         {
-            //std::cout << "Current mu = " << parsOn(k, 0) << std::endl;
+            //Info << "Current mu = " << parsOn(k, 0) << endl;
             //example.meshPtr().movePoints( example.Mesh0->points());
             word param_name = "damping";
             testkOff.updateStiffnessAndRebuildSolver(parsOn(k, 0), param_name);
@@ -281,8 +281,8 @@ int main(int argc, char* argv[])
 
     for (label i = 0; i < parsOn.rows(); i++)
     {
-        // std::cout << "Current mu = "
-        //           << parsOn(i,0) << std::endl;
+        // Info << "Current mu = "
+        //           << parsOn(i,0) << endl;
         //example.meshPtr().movePoints( example.Mesh0->points());
         word param_name = "damping";
         example.updateStiffnessAndRebuildSolver(parsOn(i, 0), param_name);
@@ -322,11 +322,11 @@ int main(int argc, char* argv[])
     }
 
     //durationOn = (std::clock() - startOn);
-    //std::cout << "The Online  phase  duration  is  equal  to " << durationOn << std::endl;
-    exit(0);
+    //Info << "The Online  phase  duration  is  equal  to " << durationOn << endl;
+    return 0;
     Eigen::MatrixXd errL2U = ITHACAutilities::errorL2Rel(example.Ufield,
                              reduced.UredFields);
-    std::cout <<
+    Info <<
     "======================= errL2U completed================================" <<
     "\n";
     Eigen::MatrixXd errL2P = ITHACAutilities::errorL2Rel(example.Pfield,
@@ -335,5 +335,5 @@ int main(int argc, char* argv[])
                    NmodesUproj) + "_" + name(NmodesPproj) + ".npy");
     cnpy::save(errL2P, "./ITHACAoutput/DataFromRom/errL2P_" + name(
                    NmodesUproj) + "_" + name(NmodesPproj) + ".npy");
-    exit(0);
+    return 0;
 }

--- a/tutorials/CFD/26MovingAirfoil/CompressibleUnSteadyPimpleTutorial.C
+++ b/tutorials/CFD/26MovingAirfoil/CompressibleUnSteadyPimpleTutorial.C
@@ -116,8 +116,8 @@ int main(int argc, char* argv[])
     example.offlineSolve();
     //exit(0);
     durationOff = (std::clock() - startOff);
-    std::cout << "The Offline phase  duration  is  equal  to " << durationOff <<
-              std::endl;
+    Info << "The Offline phase  duration  is  equal  to " << durationOff <<
+              endl;
 
     if (example.podex == 0 )
     {
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
     hyperreduced.writeEvery = example.writeEvery;
     /// Solving the hyper-reduced problem
     hyperreduced.SolveHyperReducedSys(NmodesUproj, NmodesPproj, NmodesEproj);
-    exit(0);
+    return 0;
     // online.coeffL2 = ITHACAutilities::getCoeffs(example.Dfield, online.Dmodes, NmodesDproj, false);
     // if( (!ITHACAutilities::check_folder("./ITHACAoutput/Matrices/")) )
     // {
@@ -171,8 +171,8 @@ int main(int argc, char* argv[])
     //  startOn = std::clock();
     //  reduced.solveOnline_Pimple(mu_now, NmodesUproj, NmodesPproj, NmodesDproj);
     //  durationOn = (std::clock() - startOn);
-    //  std::cout << "The Online  phase  duration  is  equal  to " << durationOn << std::endl;
-    //  std::cout << "======================= ONLINE PHASE COMPLETED ================================" << "\n";
+    //  Info << "The Online  phase  duration  is  equal  to " << durationOn << endl;
+    //  Info << "======================= ONLINE PHASE COMPLETED ================================" << "\n";
     //  if (!ITHACAutilities::check_folder("./ITHACAoutput/DataFromRom"))
     //  {
     //      mkDir("ITHACAoutput/DataFromRom");
@@ -189,11 +189,11 @@ int main(int argc, char* argv[])
     //      ITHACAstream::exportMatrix(reduced.CoeffU,"CoeffsU", "python", "./ITHACAoutput/DataFromRom/ReducedCoeffs/");
     //  }
     // Eigen::MatrixXd errL2U = ITHACAutilities::errorL2Rel(example.Ufield, reduced.UredFields);
-    // std::cout << "======================= errL2U completed================================" << "\n";
+    // Info << "======================= errL2U completed================================" << "\n";
     // Eigen::MatrixXd errL2P = ITHACAutilities::errorL2Rel(example.Pfield, reduced.PredFields);
     // cnpy::save(errL2U, "./ITHACAoutput/DataFromRom/errL2U_" + name(NmodesUproj) + "_" + name(NmodesPproj) + ".npy");
     // cnpy::save(errL2P, "./ITHACAoutput/DataFromRom/errL2P_" + name(NmodesUproj) + "_" + name(NmodesPproj) + ".npy");
-    exit(0);
+    return 0;
 }
 
 

--- a/tutorials/CFD/26MovingAirfoil/HyperReducedCompressibleUnSteadyNS.C
+++ b/tutorials/CFD/26MovingAirfoil/HyperReducedCompressibleUnSteadyNS.C
@@ -61,8 +61,8 @@ HyperReducedCompressibleUnSteadyNS::HyperReducedCompressibleUnSteadyNS(
     }
 
     //problem->restart();
-    std::cout << "################ HyperReduced Ctor called ##################" <<
-              std::endl;
+    Info << "################ HyperReduced Ctor called ##################" <<
+              endl;
 }
 
 

--- a/tutorials/NN/01simpleTurbGeomClosed/01simpleTurbGeomClosed.C
+++ b/tutorials/NN/01simpleTurbGeomClosed/01simpleTurbGeomClosed.C
@@ -108,15 +108,15 @@ class SteadyNSSimpleNN : public SteadyNSSimple
                 ITHACAstream::readMiddleFields(nutFieldsTrain, nut_train,
                                                "./ITHACAoutput/Offline/");
                 /// Compute the coefficients for train
-                std::cout << "Computing the coefficients for U train" << std::endl;
+                Info << "Computing the coefficients for U train" << endl;
                 Eigen::MatrixXd coeffL2U_train = ITHACAutilities::getCoeffs(UfieldTrain,
                                                  Umodes,
                                                  0, true);
-                std::cout << "Computing the coefficients for p train" << std::endl;
+                Info << "Computing the coefficients for p train" << endl;
                 Eigen::MatrixXd coeffL2P_train = ITHACAutilities::getCoeffs(PfieldTrain,
                                                  Pmodes,
                                                  0, true);
-                std::cout << "Computing the coefficients for nuT train" << std::endl;
+                Info << "Computing the coefficients for nuT train" << endl;
                 Eigen::MatrixXd coeffL2Nut_train = ITHACAutilities::getCoeffs(nutFieldsTrain,
                                                    nutModes,
                                                    0, true);
@@ -288,7 +288,7 @@ class reducedSimpleSteadyNN : public reducedSimpleSteadyNS
                     iter < maxIterOn)
             {
                 iter++;
-                std::cout << iter << std::endl;
+                Info << iter << endl;
 #if defined(OFVER) && (OFVER == 6)
                 simple.loop(runTime);
 #else
@@ -380,27 +380,27 @@ class reducedSimpleSteadyNN : public reducedSimpleSteadyNS
 
                 if (problem->para->debug)
                 {
-                    std::cout << "Residual jump = " << residual_jump << std::endl;
-                    std::cout << "Normalized residual = " << std::max(U_norm_res,
-                              P_norm_res) << std::endl;
-                    std::cout << "Final normalized residual for velocity: " << U_norm_res <<
-                              std::endl;
-                    std::cout << "Final normalized residual for pressure: " << P_norm_res <<
-                              std::endl;
+                    Info << "Residual jump = " << residual_jump << endl;
+                    Info << "Normalized residual = " << std::max(U_norm_res,
+                              P_norm_res) << endl;
+                    Info << "Final normalized residual for velocity: " << U_norm_res <<
+                              endl;
+                    Info << "Final normalized residual for pressure: " << P_norm_res <<
+                              endl;
                 }
 
-                res_os_U << U_norm_res << std::endl;
-                res_os_P << P_norm_res << std::endl;
+                res_os_U << U_norm_res << endl;
+                res_os_P << P_norm_res << endl;
             }
 
             res_os_U.close();
             res_os_P.close();
-            std::cout << "Solution " << counter << " converged in " << iter <<
-                         " iterations." << std::endl;
-            std::cout << "Final normalized residual for velocity: " << U_norm_res <<
-                      std::endl;
-            std::cout << "Final normalized residual for pressure: " << P_norm_res <<
-                      std::endl;
+            Info << "Solution " << counter << " converged in " << iter <<
+                         " iterations." << endl;
+            Info << "Final normalized residual for velocity: " << U_norm_res <<
+                      endl;
+            Info << "Final normalized residual for pressure: " << P_norm_res <<
+                      endl;
             problem->Umodes.reconstruct(U, a, "Uaux");
             problem->Pmodes.reconstruct(P, b, "Paux");
 
@@ -638,8 +638,8 @@ int main(int argc, char* argv[])
     Eigen::MatrixXd vel = ITHACAstream::readMatrix(vel_file);
     // Set the maximum iterations number for the online phase
     reduced.maxIterOn = para->ITHACAdict->lookupOrDefault<int>("maxIterOn", 2000);
-    std::cout << "Total amout of parameters to be solved online: " + name(
-                  angOn.rows()) << std::endl;
+    Info << "Total amout of parameters to be solved online: " + name(
+                  angOn.rows()) << endl;
     //Perform the online solutions
     std::clock_t startOn;
     double durationOn;
@@ -647,7 +647,7 @@ int main(int argc, char* argv[])
 
     for (label k = 0; k < angOn.rows(); k++)
     {
-        std::cout << "Solving online for parameter number " + name(k + 1) << std::endl;
+        Info << "Solving online for parameter number " + name(k + 1) << endl;
         scalar mu_now = angOn(k, 0);
         example.restart();
         reduced.vel_now = vel;
@@ -699,7 +699,7 @@ int main(int argc, char* argv[])
     }
 
     durationOn = (std::clock() - startOn);
-    std::cout << "ONLINE PHASE COMPLETED" << std::endl;
+    Info << "ONLINE PHASE COMPLETED" << endl;
     PtrList<volVectorField> Ufull;
     PtrList<volScalarField> Pfull;
     PtrList<volVectorField> Ured;
@@ -737,9 +737,9 @@ int main(int argc, char* argv[])
     ITHACAstream::exportMatrix(relErrorP,
                                "errorP_" + name(example.NUmodes) + "_" + name(example.NPmodes) + "_" + name(
                                    example.NNutModes), "python", ".");
-    std::cout << "The online phase duration is equal to " << durationOn <<
-              std::endl;
-    std::cout << "The offline phase duration is equal to " << durationOff <<
-              std::endl;
-    exit(0);
+    Info << "The online phase duration is equal to " << durationOn <<
+              endl;
+    Info << "The offline phase duration is equal to " << durationOff <<
+              endl;
+    return 0;
 }

--- a/tutorials/NN/BumpCompressibleSteadyNS/02compBump.C
+++ b/tutorials/NN/BumpCompressibleSteadyNS/02compBump.C
@@ -118,15 +118,15 @@ class CompressibleSteadyNN : public CompressibleSteadyNS
                 ITHACAstream::readMiddleFields(nutFieldsTrain, nut_train,
                                                "./ITHACAoutput/Offline/");
                 /// Compute the coefficients for train
-                std::cout << "Computing the coefficients for U train" << std::endl;
+                Info << "Computing the coefficients for U train" << endl;
                 Eigen::MatrixXd coeffL2U_train = ITHACAutilities::getCoeffs(UfieldTrain,
                                                  Umodes,
                                                  0, true);
-                std::cout << "Computing the coefficients for p train" << std::endl;
+                Info << "Computing the coefficients for p train" << endl;
                 Eigen::MatrixXd coeffL2P_train = ITHACAutilities::getCoeffs(PfieldTrain,
                                                  Pmodes,
                                                  0, true);
-                std::cout << "Computing the coefficients for nuT train" << std::endl;
+                Info << "Computing the coefficients for nuT train" << endl;
                 Eigen::MatrixXd coeffL2Nut_train = ITHACAutilities::getCoeffs(nutFieldsTrain,
                                                    nutModes,
                                                    0, true);
@@ -400,12 +400,12 @@ class ReducedCompressibleSteadyNN : public ReducedCompressibleSteadyNS
 
                 rho = thermo.rho(); // Here rho is calculated as p*psi = p/(R*T)
                 rho.relax();
-                std::cout << "Ures = " << (uResidual.cwiseAbs()).sum() /
-                          (RedLinSysU[1].cwiseAbs()).sum() << std::endl;
-                std::cout << "Eres = " << (eResidual.cwiseAbs()).sum() /
-                          (RedLinSysE[1].cwiseAbs()).sum() << std::endl;
-                std::cout << "Pres = " << (pResidual.cwiseAbs()).sum() /
-                          (RedLinSysP[1].cwiseAbs()).sum() << std::endl;
+                Info << "Ures = " << (uResidual.cwiseAbs()).sum() /
+                          (RedLinSysU[1].cwiseAbs()).sum() << endl;
+                Info << "Eres = " << (eResidual.cwiseAbs()).sum() /
+                          (RedLinSysE[1].cwiseAbs()).sum() << endl;
+                Info << "Pres = " << (pResidual.cwiseAbs()).sum() /
+                          (RedLinSysP[1].cwiseAbs()).sum() << endl;
                 residualNorm = max(max((uResidual.cwiseAbs()).sum() /
                                        (RedLinSysU[1].cwiseAbs()).sum(),
                                        (pResidual.cwiseAbs()).sum() / (RedLinSysP[1].cwiseAbs()).sum()),
@@ -455,7 +455,7 @@ class tutorial02 : public CompressibleSteadyNN
             );
             ITHACAutilities::getPointsFromPatch(_mesh(), 0, top0, top0_ind);
             ITHACAutilities::getPointsFromPatch(_mesh(), 1, bot0, bot0_ind);
-            // std::cout << _mesh().points().size() << std::endl;
+            // Info << _mesh().points().size() << endl;
             ms = new RBFMotionSolver(_mesh(), *dyndict);
             vectorField motion(ms->movingPoints().size(), vector::zero);
             movingIDs = ms->movingIDs();
@@ -505,7 +505,7 @@ class tutorial02 : public CompressibleSteadyNN
 
             if (parTop != 0 || parBot != 0)
             {
-                // std::cout << parTop << std::endl;
+                // Info << parTop << endl;
                 List<vector> top0_cur = moveBasis(top0, parTop);
                 List<vector> bot0_cur = moveBasis(bot0, parBot);
                 ITHACAutilities::setIndices2Value(top0_ind, top0_cur, movingIDs, curX);
@@ -678,7 +678,7 @@ int main(int argc, char* argv[])
         ITHACAstream::writePoints(example._mesh().points(),
                                   "./ITHACAoutput/Online_" + name(NmodesUproj) + "_" + name(NmodesNutProj) + "/",
                                   name(k + 1) + "/polyMesh/");
-        //std::cout << example.inletIndex.rows() << std::endl;
+        //Info << example.inletIndex.rows() << endl;
         //reduced.setOnlineVelocity(vel);
         reduced.projectReducedOperators(NmodesUproj, NmodesPproj, NmodesEproj);
         example.restart();
@@ -824,8 +824,8 @@ int main(int argc, char* argv[])
     else
     {
         std::cerr << "checkOff folder is missing, error analysis cannot be performed."
-                  << std::endl;
+                  << endl;
     }
 
-    exit(0);
+    return 0;
 }

--- a/tutorials/NN/CompressibleSteadyNS/03compSteadyNS.C
+++ b/tutorials/NN/CompressibleSteadyNS/03compSteadyNS.C
@@ -117,15 +117,15 @@ class CompressibleSteadyNN : public CompressibleSteadyNS
                 ITHACAstream::readMiddleFields(nutFieldsTrain, nut_train,
                                                "./ITHACAoutput/Offline/");
                 /// Compute the coefficients for train
-                std::cout << "Computing the coefficients for U train" << std::endl;
+                Info << "Computing the coefficients for U train" << endl;
                 Eigen::MatrixXd coeffL2U_train = ITHACAutilities::getCoeffs(UfieldTrain,
                                                  Umodes,
                                                  0, true);
-                std::cout << "Computing the coefficients for p train" << std::endl;
+                Info << "Computing the coefficients for p train" << endl;
                 Eigen::MatrixXd coeffL2P_train = ITHACAutilities::getCoeffs(PfieldTrain,
                                                  Pmodes,
                                                  0, true);
-                std::cout << "Computing the coefficients for nuT train" << std::endl;
+                Info << "Computing the coefficients for nuT train" << endl;
                 Eigen::MatrixXd coeffL2Nut_train = ITHACAutilities::getCoeffs(nutFieldsTrain,
                                                    nutModes,
                                                    0, true);
@@ -184,15 +184,15 @@ class CompressibleSteadyNN : public CompressibleSteadyNS
         //         ITHACAstream::readMiddleFields(nutFieldsTrain, nut_train,
         //                                        "./ITHACAoutput/Offline/");
         //         /// Compute the coefficients for train
-        //         std::cout << "Computing the coefficients for U train" << std::endl;
+        //         Info << "Computing the coefficients for U train" << endl;
         //         Eigen::MatrixXd coeffL2U_train = ITHACAutilities::getCoeffs(UfieldTrain,
         //                                          Umodes,
         //                                          0, true);
-        //         std::cout << "Computing the coefficients for p train" << std::endl;
+        //         Info << "Computing the coefficients for p train" << endl;
         //         Eigen::MatrixXd coeffL2P_train = ITHACAutilities::getCoeffs(PfieldTrain,
         //                                          Pmodes,
         //                                          0, true);
-        //         std::cout << "Computing the coefficients for nuT train" << std::endl;
+        //         Info << "Computing the coefficients for nuT train" << endl;
         //         Eigen::MatrixXd coeffL2Nut_train = ITHACAutilities::getCoeffs(nutFieldsTrain,
         //                                            nutModes,
         //                                            0, true);
@@ -472,12 +472,12 @@ class ReducedCompressibleSteadyNN : public ReducedCompressibleSteadyNS
 
                 rho = thermo.rho(); // Here rho is calculated as p*psi = p/(R*T)
                 rho.relax();
-                std::cout << "Ures = " << (uResidual.cwiseAbs()).sum() /
-                          (RedLinSysU[1].cwiseAbs()).sum() << std::endl;
-                std::cout << "Eres = " << (eResidual.cwiseAbs()).sum() /
-                          (RedLinSysE[1].cwiseAbs()).sum() << std::endl;
-                std::cout << "Pres = " << (pResidual.cwiseAbs()).sum() /
-                          (RedLinSysP[1].cwiseAbs()).sum() << std::endl;
+                Info << "Ures = " << (uResidual.cwiseAbs()).sum() /
+                          (RedLinSysU[1].cwiseAbs()).sum() << endl;
+                Info << "Eres = " << (eResidual.cwiseAbs()).sum() /
+                          (RedLinSysE[1].cwiseAbs()).sum() << endl;
+                Info << "Pres = " << (pResidual.cwiseAbs()).sum() /
+                          (RedLinSysP[1].cwiseAbs()).sum() << endl;
                 residualNorm = max(max((uResidual.cwiseAbs()).sum() /
                                        (RedLinSysU[1].cwiseAbs()).sum(),
                                        (pResidual.cwiseAbs()).sum() / (RedLinSysP[1].cwiseAbs()).sum()),
@@ -556,12 +556,12 @@ class tutorial03 : public CompressibleSteadyNN
                 {
                     //std::clock_t startOff;
                     //startOff = std::clock();
-                    std::cout << "Current mu = " << mu(i, 0) << std::endl;
+                    Info << "Current mu = " << mu(i, 0) << endl;
                     changeViscosity(mu(i, 0));
                     assignIF(_U(), Uinl);
                     truthSolve(folder);
                     //durationOff = (std::clock() - startOff);
-                    //cpuTimes << durationOff << std::endl;
+                    //cpuTimes << durationOff << endl;
                 }
             }
 
@@ -579,7 +579,7 @@ int main(int argc, char* argv[])
     // exit(0);
     //std::clock_t startOff, startOn;
     //double durationOn, durationOff;
-    std::cerr << "debug point 1" << std::endl;
+    std::cerr << "debug point 1" << endl;
     ITHACAparameters* para = ITHACAparameters::getInstance();
     //Eigen::MatrixXd parOff;
     std::ifstream exFileOff("./parsOff_mat.txt");
@@ -610,7 +610,7 @@ int main(int argc, char* argv[])
         ITHACAstream::exportMatrix(parsOn, "parsOn", "eigen", "./");
     }
 
-    std::cerr << "debug point 2" << std::endl;
+    std::cerr << "debug point 2" << endl;
     // Read some parameters from file
     int NmodesUout = para->ITHACAdict->lookupOrDefault<int>("NmodesUout", 15);
     int NmodesPout = para->ITHACAdict->lookupOrDefault<int>("NmodesPout", 15);
@@ -625,9 +625,9 @@ int main(int argc, char* argv[])
     // example.inletIndex(0, 0) = 1;
     // example.inletIndex(0, 1) = 0;
     //Perform the offline solve
-    std::cerr << "debug point 3" << std::endl;
+    std::cerr << "debug point 3" << endl;
     example.offlineSolve();
-    std::cerr << "debug point 4" << std::endl;
+    std::cerr << "debug point 4" << endl;
     //Read the lift field
     // ITHACAstream::read_fields(example.liftfield, example._U(), "./lift/");
     // ITHACAutilities::normalizeFields(example.liftfield);
@@ -734,16 +734,16 @@ int main(int argc, char* argv[])
             example.changeViscosity(mu_now(0, 0));
             // reduced.setOnlineVelocity(vel);
             reduced.projectReducedOperators(NmodesUproj, NmodesPproj, NmodesEproj);
-            //std::cout << "############################" << std::endl;
+            //Info << "############################" << endl;
             example.restart();
             example.turbulence->validate();
-            //std::cout << "##############################################################" << std::endl;
+            //Info << "##############################################################" << endl;
             // reduced.solveOnlineCompressible(mu_now, NmodesUproj, NmodesPproj, NmodesEproj);
             reduced.solveOnlineCompressible(NmodesUproj, NmodesPproj, NmodesEproj,
                                             NmodesNutProj, mu_now, "./ITHACAoutput/Online_" + name(NmodesUproj) + "_" +
                                             name(NmodesNutProj) + "/");
             durationOn = std::clock() - startOn;
-            cpuTimes << durationOn << std::endl;
+            cpuTimes << durationOn << endl;
         }
     }
     //// Read the files
@@ -782,21 +782,21 @@ int main(int argc, char* argv[])
             //auto err = foam2Eigen::foam2Eigen
             auto u = ITHACAutilities::L2Norm(offlineU[j]);
             Ue /= u;
-            //std::cout << "Ue = " << ITHACAutilities::L2Norm(Ue)/u << std::endl;
+            //Info << "Ue = " << ITHACAutilities::L2Norm(Ue)/u << endl;
             //////////
             volScalarField Pe = offlineP[j] - onlineP[j];
             auto p = ITHACAutilities::L2Norm(offlineP[j]);
             Pe /= p;
-            //std::cout << "Pe = " <<  ITHACAutilities::L2Norm(Pe)/p << std::endl;
+            //Info << "Pe = " <<  ITHACAutilities::L2Norm(Pe)/p << endl;
             ////////
             volScalarField Ee = offlineE[j] - onlineE[j];
             auto e = ITHACAutilities::L2Norm(offlineE[j]);
             Ee /= e;
-            //std::cout << "Ee = " <<  ITHACAutilities::L2Norm(Ee)/e << std::endl;
+            //Info << "Ee = " <<  ITHACAutilities::L2Norm(Ee)/e << endl;
             volScalarField Nute = offlineNut[j] - onlineNut[j];
             auto n = ITHACAutilities::L2Norm(offlineNut[j]);
             Nute /= n;
-            //std::cout << "Nute = " <<  ITHACAutilities::L2Norm(Nute)/n << std::endl;
+            //Info << "Nute = " <<  ITHACAutilities::L2Norm(Nute)/n << endl;
             Ue.rename("Ue");
             Pe.rename("Pe");
             Ee.rename("Ee");
@@ -889,14 +889,14 @@ int main(int argc, char* argv[])
     //                 example.changeViscosity(mu_now(0,0));
     //                 // reduced.setOnlineVelocity(vel);
     //                 reduced.projectReducedOperators(NmodesUproj, NmodesPproj, NmodesEproj);
-    //                 //std::cout << "############################" << std::endl;
+    //                 //Info << "############################" << endl;
     //                 example.restart();
     //                 example.turbulence->validate();
-    //                 std::cout << "##############################################################" << std::endl;
+    //                 Info << "##############################################################" << endl;
     //                 // reduced.solveOnlineCompressible(mu_now, NmodesUproj, NmodesPproj, NmodesEproj);
     //                 reduced.solveOnlineCompressible(mu_now, NmodesUproj, NmodesPproj, NmodesEproj, NmodesNutProj, "./ITHACAoutput/Online_" + name(NmodesUproj) + "_"+name(NmodesNutProj) + "/");
     //                 durationOn = std::clock() - startOn;
-    //                 cpuTimes << durationOn << std::endl;
+    //                 cpuTimes << durationOn << endl;
     //             }
     //         }
     //         //// Read the files
@@ -949,7 +949,7 @@ int main(int argc, char* argv[])
     // }
     // else
     // {
-    //     std::cerr << "CheckOff folder is missing, error analysis cannot be performed." << std::endl;
+    //     std::cerr << "CheckOff folder is missing, error analysis cannot be performed." << endl;
     // }
     exit(0);
 }

--- a/tutorials/UQ/01enKF/01enKF.C
+++ b/tutorials/UQ/01enKF/01enKF.C
@@ -53,17 +53,17 @@ int main(int argc, char* argv[])
     Eigen::VectorXd x0 = ITHACAstream::readMatrix("initialState_mat.txt").col(0);
     int stateSize = A.rows();
     int obsSize = H.rows();
-    std::cout <<
+    Info <<
     "In this tutorial we have a dynamical system in the form:\ndx/dt = A * x" <<
-              std::endl;
-    std::cout << "with A = \n" << A << std::endl;
-    std::cout << "We observe the state x by mean of the observation matrix \nH = \n"
-              << H << std::endl;
-    std::cout <<
+              endl;
+    Info << "with A = \n" << A << endl;
+    Info << "We observe the state x by mean of the observation matrix \nH = \n"
+              << H << endl;
+    Info <<
     "The objective is to reconstruct the vector state knowing H and x0 = \n" <<
               x0.transpose() <<
-    "\nbut having a wrong A" << std::endl;
-    std::cout << "A_wrong =\n" << Aw << std::endl;
+    "\nbut having a wrong A" << endl;
+    Info << "A_wrong =\n" << Aw << endl;
     int Ntimes = 201;
     int sampleDeltaStep = 10;
     double endTime = 10;

--- a/unitTests/Foam2Eigen/Foam2EigenTest.C
+++ b/unitTests/Foam2Eigen/Foam2EigenTest.C
@@ -117,12 +117,12 @@ Foam::fvMesh& mesh = meshPtr();
     Info << p << endl;
 
     Info << "\nFirst two elements of p, by reference:\n" << endl;
-    std::cerr << *(&p.ref()[0]) << std::endl;
-    std::cerr << *(&p.ref()[0]+1) << std::endl;
+    std::cerr << *(&p.ref()[0]) << endl;
+    std::cerr << *(&p.ref()[0]+1) << endl;
 
     Info << "\nFirst two elements of p_eigen:\n" << endl;
-    std::cerr << p_eigen(0) << std::endl;
-    std::cerr << p_eigen(1) << std::endl;
+    std::cerr << p_eigen(0) << endl;
+    std::cerr << p_eigen(1) << endl;
 
     // Change p_eigen
     p_eigen(0) = 0.0;
@@ -149,29 +149,29 @@ Foam::fvMesh& mesh = meshPtr();
     Eigen::VectorXd U_eigen;
     U_eigen = Foam2Eigen::field2Eigen(U);
 
-    std::cerr << "\nFirst 4 elements of U, by reference:\n" << std::endl;
+    std::cerr << "\nFirst 4 elements of U, by reference:\n" << endl;
     Info << *(&U.ref()[0][0]) << endl;
     Info << *(&U.ref()[0][0]+1) << endl;
     Info << *(&U.ref()[0][0]+2) << endl;
     Info << *(&U.ref()[0][0]+3) << endl;
 
-    std::cerr << "\nFirst 4 elements of U_eigen:\n" << std::endl;
-    std::cerr << U_eigen(0) << std::endl;
-    std::cerr << U_eigen(1) << std::endl;
-    std::cerr << U_eigen(2) << std::endl;
-    std::cerr << U_eigen(3) << std::endl;
+    std::cerr << "\nFirst 4 elements of U_eigen:\n" << endl;
+    std::cerr << U_eigen(0) << endl;
+    std::cerr << U_eigen(1) << endl;
+    std::cerr << U_eigen(2) << endl;
+    std::cerr << U_eigen(3) << endl;
     
     // Change U_eigen
     U_eigen(3) = 0.0;
     U = Foam2Eigen::Eigen2field(U, U_eigen, false);
-    std::cerr << "\nConverting back to field:, after setting U_eigen(3) = 0.0 (second row, first column)\n" << std::endl;
+    std::cerr << "\nConverting back to field:, after setting U_eigen(3) = 0.0 (second row, first column)\n" << endl;
     Info << U << endl;
 
     // uncomment lines below to test error handling for wrong size
     // Info << "\nConverting back to field with a resized U (9×3). Eigen2Field should throw an error:\n" << endl;
     // Eigen::MatrixXd U_eigen_r = Eigen::Map<Eigen::MatrixXd>((U_eigen.data()),3 ,9);
     // U_eigen_r.transposeInPlace();
-    // std::cerr << U_eigen_r << std::endl;
+    // std::cerr << U_eigen_r << endl;
     // volVectorField UU(U);
     // Foam2Eigen::Eigen2field(UU, U_eigen_r, false);
 
@@ -213,7 +213,7 @@ Foam::fvMesh& mesh = meshPtr();
 
     // Change R_eigen
     R_eigen(9) = 0.0;
-    std::cerr << "\nConverting back to field, after setting R_eigen(9) = 0.0 (First row, first column, second element):\n" << std::endl;
+    std::cerr << "\nConverting back to field, after setting R_eigen(9) = 0.0 (First row, first column, second element):\n" << endl;
     R = Foam2Eigen::Eigen2field(R, R_eigen, false);
     Info << R << endl;
     // exit(0);
@@ -222,7 +222,7 @@ Foam::fvMesh& mesh = meshPtr();
     // Eigen::MatrixXd R_eigen_r = Eigen::Map<Eigen::MatrixXd>((R_eigen.data()),9 ,9);
     // R_eigen_r.transposeInPlace();
     // Info << "\nResized R_eigen:\n" << endl;
-    // std::cerr << R_eigen_r << std::endl;
+    // std::cerr << R_eigen_r << endl;
     // volTensorField RR(R);
     // Info << "\nConverting back to field with a resized U (9×9). Eigen2Field should throw an error:\n" << endl;
     // Foam2Eigen::Eigen2field(RR, R_eigen_r, false);

--- a/unitTests/ITHACAstream/StreamTest.C
+++ b/unitTests/ITHACAstream/StreamTest.C
@@ -26,7 +26,7 @@ bool ReadAndWriteTensor()
     if (difference(0) < comp(0))
     {
         esit = true;
-        std::cout << "> Read And Write Test for tensors succeeded!" << std::endl;
+        Foam::Info << "> Read And Write Test for tensors succeeded!" << Foam::endl;
     }
 
     system("rm output");
@@ -99,7 +99,7 @@ bool ReadAndWriteNPYMatrix()
             && difference_TI == 0 && difference_TD == 0 && difference_TF == 0)
     {
         esit = true;
-        std::cout << "> Read And Write NPY matrix succeeded!" << std::endl;
+        Foam::Info << "> Read And Write NPY matrix succeeded!" << Foam::endl;
     }
 
     system("rm *.npy");
@@ -157,7 +157,7 @@ int cnpyTEST()
     Eigen::MatrixXf pc1 = Eigen::MatrixXf::Random(5, 5);
     cnpy::save(pc1, "arr.npy");
     Eigen::MatrixXf pc0 = cnpy::load(pc0, "arr.npy");
-    std::cout << pc0 << std::endl;
+    Foam::Info << pc0 << Foam::endl;
     cnpy::save(pc0, "test.npy");
     return 0;
 }
@@ -169,13 +169,13 @@ int TestSparseMatrix()
     cnpy::save(mat,"forNpy.npz");
     Eigen::SparseMatrix<double> mat2;
     cnpy::load(mat2,"forNpy.npz");
-    // std::cout << mat2 << std::endl;
+    // Foam::Info << mat2 << Foam::endl;
     bool esit = false;
 
     if ((mat-mat2).norm() == 0)
     {
         esit = true;
-        std::cout << "> Read And Write NPZ sparse matrix succeeded!" << std::endl;
+        Foam::Info << "> Read And Write NPZ sparse matrix succeeded!" << Foam::endl;
     }
     return esit;
 }

--- a/unitTests/OptimLib/ADAM/ADAM.C
+++ b/unitTests/OptimLib/ADAM/ADAM.C
@@ -47,14 +47,14 @@ int main()
 
     if (success)
     {
-        std::cout << "gd: sphere test completed successfully." << "\n";
+        Info << "gd: sphere test completed successfully." << "\n";
     }
 
     else
     {
-        std::cout << "gd: sphere test completed unsuccessfully." << "\n";
+        Info << "gd: sphere test completed unsuccessfully." << "\n";
     }
 
-    std::cout << "gd: solution to sphere test:\n" << x << std::endl;
+    Info << "gd: solution to sphere test:\n" << x << endl;
     return 0;
 }

--- a/unitTests/UQ/quantileTest/quantileTest.C
+++ b/unitTests/UQ/quantileTest/quantileTest.C
@@ -43,13 +43,13 @@ SourceFiles
 
 int main(int argc, char* argv[])
 {
-    std::cout << "******************************************************" << std::endl;
-    std::cout << "\nTEST of the function ITHACAmuq::muq2ithaca::quantile" << std::endl;
-    std::cout << "We sample from a Gaussian distribution with mean mu = 0"<< std::endl;
-    std::cout << "and variance sigma = 1.\n "<< std::endl;
-    std::cout << "For this distribution, the p-quantile is given by\n\n" <<
-         "mu + sigma * sqrt(2) * invErf(2 * p - 1)\n" << std::endl;
-    std::cout << "Several methods to approximate the quantile have been implemented and are here tested." << std::endl;
+    Info << "******************************************************" << endl;
+    Info << "\nTEST of the function ITHACAmuq::muq2ithaca::quantile" << endl;
+    Info << "We sample from a Gaussian distribution with mean mu = 0"<< endl;
+    Info << "and variance sigma = 1.\n "<< endl;
+    Info << "For this distribution, the p-quantile is given by\n\n" <<
+         "mu + sigma * sqrt(2) * invErf(2 * p - 1)\n" << endl;
+    Info << "Several methods to approximate the quantile have been implemented and are here tested." << endl;
 
 
 
@@ -57,9 +57,9 @@ int main(int argc, char* argv[])
     auto density = std::make_shared<muq::Modeling::Gaussian>(nSeeds);
     Eigen::VectorXd samps = density->Sample();
     double p = 0.3;
-    std::cout << "\nQuantile method 1 = " << ITHACAmuq::muq2ithaca::quantile(samps, p, 1) << std::endl;
-    std::cout << "Quantile method 2 = " << ITHACAmuq::muq2ithaca::quantile(samps, p, 2) << std::endl;
-    std::cout << "Quantile method 3 = " << ITHACAmuq::muq2ithaca::quantile(samps, p, 3) << std::endl;
-    std::cout << "True quantile = " << std::sqrt(2) * boost::math::erf_inv(2 * p - 1) << std::endl;
+    Info << "\nQuantile method 1 = " << ITHACAmuq::muq2ithaca::quantile(samps, p, 1) << endl;
+    Info << "Quantile method 2 = " << ITHACAmuq::muq2ithaca::quantile(samps, p, 2) << endl;
+    Info << "Quantile method 3 = " << ITHACAmuq::muq2ithaca::quantile(samps, p, 3) << endl;
+    Info << "True quantile = " << std::sqrt(2) * boost::math::erf_inv(2 * p - 1) << endl;
     return 0;
 }

--- a/unitTests/ithacaInterpolator/Test_ithacaInterpolator.C
+++ b/unitTests/ithacaInterpolator/Test_ithacaInterpolator.C
@@ -37,6 +37,8 @@ License
 #include <iomanip>
 #include "dictionary.H"
 #include "IFstream.H"
+#include "Ostream.H"
+#include "IOmanip.H"
 
 // Function to approximate: z = sin(x) * cos(y)
 double targetFunction(double x, double y)
@@ -116,7 +118,7 @@ double evaluateModel(ithacaInterpolator& model, int nTest, double minVal, double
 
 int main(int argc, char **argv)
 {
-    std::cout << "Comprehensive test of RBF and GPR kernels with different packages..." << std::endl;
+    Foam::Info << "Comprehensive test of RBF and GPR kernels with different packages..." << Foam::endl;
 
     // 1. Generate Training Data
     int nSamples = 20;
@@ -181,9 +183,9 @@ int main(int argc, char **argv)
 
     for (const auto& config : configs)
     {
-        std::cout << "\n" << std::string(60, '=') << std::endl;
-        std::cout << "Testing: " << config.description << std::endl;
-        std::cout << std::string(60, '=') << std::endl;
+        Foam::Info << "\n" << std::string(60, '=') << Foam::endl;
+        Foam::Info << "Testing: " << config.description << Foam::endl;
+        Foam::Info << std::string(60, '=') << Foam::endl;
 
         try
         {
@@ -195,7 +197,7 @@ int main(int argc, char **argv)
             model.printInfo();
 
             // Fit the model
-            std::cout << "Fitting the model..." << std::endl;
+            Foam::Info << "Fitting the model..." << Foam::endl;
             model.fit(X_train, y_train);
 
             // Evaluate performance
@@ -204,29 +206,29 @@ int main(int argc, char **argv)
             mae_values.push_back(mae);
             descriptions.push_back(config.description);
 
-            std::cout << "Mean Absolute Error: " << mae << std::endl;
-            std::cout << "Test PASSED" << std::endl;
+            Foam::Info << "Mean Absolute Error: " << mae << Foam::endl;
+            Foam::Info << "Test PASSED" << Foam::endl;
         }
         catch (const std::exception& e)
         {
-            std::cout << "Test FAILED with exception: " << e.what() << std::endl;
+            Foam::Info << "Test FAILED with exception: " << e.what() << Foam::endl;
             mae_values.push_back(std::numeric_limits<double>::max());
             descriptions.push_back(config.description + " (FAILED)");
         }
     }
 
     // 4. Summary and comparison
-    std::cout << "\n" << std::string(80, '=') << std::endl;
-    std::cout << "SUMMARY OF RESULTS" << std::endl;
-    std::cout << std::string(80, '=') << std::endl;
+    Foam::Info << "\n" << std::string(80, '=') << Foam::endl;
+    Foam::Info << "SUMMARY OF RESULTS" << Foam::endl;
+    Foam::Info << std::string(80, '=') << Foam::endl;
 
-    std::cout << std::left << std::setw(50) << "Configuration" << std::setw(15) << "MAE" << std::endl;
-    std::cout << std::string(65, '-') << std::endl;
+    Foam::Info << std::left << Foam::setw(50) << "Configuration" << Foam::setw(15) << "MAE" << Foam::endl;
+    Foam::Info << std::string(65, '-') << Foam::endl;
 
     for (size_t i = 0; i < descriptions.size(); ++i)
     {
-        std::cout << std::left << std::setw(50) << descriptions[i]
-                  << std::setw(15) << (mae_values[i] == std::numeric_limits<double>::max() ? "FAILED" : std::to_string(mae_values[i])) << std::endl;
+        Foam::Info << std::left << Foam::setw(50) << descriptions[i]
+                  << Foam::setw(15) << (mae_values[i] == std::numeric_limits<double>::max() ? "FAILED" : std::to_string(mae_values[i])) << Foam::endl;
     }
 
     // Find best performing configuration (excluding failed ones)
@@ -243,8 +245,8 @@ int main(int argc, char **argv)
 
     if (best_mae != std::numeric_limits<double>::max())
     {
-        std::cout << "\nBest performing configuration:" << std::endl;
-        std::cout << descriptions[best_idx] << " with MAE = " << best_mae << std::endl;
+        Foam::Info << "\nBest performing configuration:" << Foam::endl;
+        Foam::Info << descriptions[best_idx] << " with MAE = " << best_mae << Foam::endl;
     }
 
     return 0;

--- a/unitTests/libTorch/torchOperations.C
+++ b/unitTests/libTorch/torchOperations.C
@@ -41,10 +41,10 @@ using namespace ITHACAtorch::torch2Eigen;
 int main()
 {
     torch::Tensor tensor = torch::randn({2, 2, 3});
-    std::cout << tensor << std::endl;
+    Info << tensor << endl;
     ITHACAtorch::save(tensor,"test.npy");
     torch::Tensor aloaded = ITHACAtorch::load("test.npy");
-    std::cout << aloaded << std::endl;
+    Info << aloaded << endl;
     return 0;
 
 }

--- a/unitTests/pybind11/residual_of/of_pybind11_system.C
+++ b/unitTests/pybind11/residual_of/of_pybind11_system.C
@@ -99,7 +99,7 @@ public:
 
     void printMatrix(Eigen::Ref<Eigen::MatrixXd>& a)
     {
-        std::cerr << a << std::endl;
+        std::cerr << a << endl;
     }
 
     Eigen::SparseMatrix<double> get_system_matrix(Eigen::VectorXd& T, Eigen::VectorXd& S)

--- a/unitTests/splinter/test.C
+++ b/unitTests/splinter/test.C
@@ -23,8 +23,7 @@
 #include <rbfspline.h>
 #include <spline.h>
 
-using std::cout;
-using std::endl;
+#include "IFstream.H"
 
 using namespace SPLINTER;
 
@@ -44,18 +43,18 @@ bool is_identical(DataTable &a, DataTable &b)
 	{
 		for(unsigned int i = 0; i < a.getNumVariables(); i++)
 		{
-//            std::cout << std::setprecision(SAVE_DOUBLE_PRECISION) << ait->getX().at(i) << " == " << std::setprecision(SAVE_DOUBLE_PRECISION) << bit->getX().at(i) << " ";
+//            Foam::Info << std::setprecision(SAVE_DOUBLE_PRECISION) << ait->getX().at(i) << " == " << std::setprecision(SAVE_DOUBLE_PRECISION) << bit->getX().at(i) << " ";
 			if(!equalsWithinRange(ait->getX().at(i), bit->getX().at(i)))
 				return false;
 		}
 
-//            std::cout << std::setprecision(SAVE_DOUBLE_PRECISION) << ait->getY().at(j) << " == " << std::setprecision(SAVE_DOUBLE_PRECISION) << bit->getY().at(j) << " ";
+//            Foam::Info << std::setprecision(SAVE_DOUBLE_PRECISION) << ait->getY().at(j) << " == " << std::setprecision(SAVE_DOUBLE_PRECISION) << bit->getY().at(j) << " ";
 		if(!equalsWithinRange(ait->getY(), bit->getY()))
 			return false;
-//        std::cout << std::endl;
+//        Foam::Info << Foam::endl;
 	}
 
-//    std::cout << "Finished comparing samples..." << std::endl;
+//    Foam::Info << "Finished comparing samples..." << Foam::endl;
 
 	return ait == a.cend() && bit == b.cend();
 }
@@ -306,30 +305,30 @@ void runExample()
     // Evaluate the splines at x = (0,0)
 	xf2(0) = 0; xf2(1) = 0; xf2(2) = 0; 	
 
-	cout << endl << endl;
-	cout << "Evaluating splines at grid point x = [0,0,0]"        << endl;
-	cout << "-------------------------------------------"       << endl;
-	cout << "Function y(x):         "   << f3(xf2)                 << endl;
-	cout << "Linear B-spline:       "   << bspline1.eval(xf2)     << endl;
-	cout << "Quadratic B-spline:    "   << bspline2.eval(xf2)     << endl;
-	cout << "Cubic B-spline:        "   << bspline3.eval(xf2)     << endl;
-	cout << "P-spline:              "   << pspline.eval(xf2)      << endl;
-    // cout << "Thin-plate RBF spline:     "   << rbfspline.eval(x)    << endl;
-	cout << "-------------------------------------------"       << endl;
+	Foam::Info << Foam::endl << Foam::endl;
+	Foam::Info << "Evaluating splines at grid point x = [0,0,0]"        << Foam::endl;
+	Foam::Info << "-------------------------------------------"       << Foam::endl;
+	Foam::Info << "Function y(x):         "   << f3(xf2)                 << Foam::endl;
+	Foam::Info << "Linear B-spline:       "   << bspline1.eval(xf2)     << Foam::endl;
+	Foam::Info << "Quadratic B-spline:    "   << bspline2.eval(xf2)     << Foam::endl;
+	Foam::Info << "Cubic B-spline:        "   << bspline3.eval(xf2)     << Foam::endl;
+	Foam::Info << "P-spline:              "   << pspline.eval(xf2)      << Foam::endl;
+    // Foam::Info << "Thin-plate RBF spline:     "   << rbfspline.eval(x)    << Foam::endl;
+	Foam::Info << "-------------------------------------------"       << Foam::endl;
 
     // Evaluate the splines at xf2 = (1,1,1)
 	xf2(0) = 1; xf2(1) = 1; xf2(2) = 1;
 
-	cout << endl << endl;
-	cout << "Evaluating splines at x = [1,1,1]"                   << endl;
-	cout << "-------------------------------------------"       << endl;
-	cout << "Function y(x):         "   << f3(xf2)                 << endl;
-	cout << "Linear B-spline:       "   << bspline1.eval(xf2)     << endl;
-	cout << "Quadratic B-spline:    "   << bspline2.eval(xf2)     << endl;
-	cout << "Cubic B-spline:        "   << bspline3.eval(xf2)     << endl;
-	cout << "P-spline:              "   << pspline.eval(xf2)      << endl;
-    // cout << "Thin-plate RBF spline:     "   << rbfspline.eval(x)    << endl;
-	cout << "-------------------------------------------"       << endl;
+	Foam::Info << Foam::endl << Foam::endl;
+	Foam::Info << "Evaluating splines at x = [1,1,1]"                   << Foam::endl;
+	Foam::Info << "-------------------------------------------"       << Foam::endl;
+	Foam::Info << "Function y(x):         "   << f3(xf2)                 << Foam::endl;
+	Foam::Info << "Linear B-spline:       "   << bspline1.eval(xf2)     << Foam::endl;
+	Foam::Info << "Quadratic B-spline:    "   << bspline2.eval(xf2)     << Foam::endl;
+	Foam::Info << "Cubic B-spline:        "   << bspline3.eval(xf2)     << Foam::endl;
+	Foam::Info << "P-spline:              "   << pspline.eval(xf2)      << Foam::endl;
+    // Foam::Info << "Thin-plate RBF spline:     "   << rbfspline.eval(x)    << Foam::endl;
+	Foam::Info << "-------------------------------------------"       << Foam::endl;
 
     // Evaluate error norm
 	auto x0_vec_2 = linspace(0, 2, 200);
@@ -357,15 +356,15 @@ void runExample()
 		}
 	}
 
-	cout << endl << endl;
-	cout << "Evaluating spline errors (using max norm)  "   << endl;
-	cout << "-------------------------------------------"   << endl;
-	cout << "Linear B-spline:      "   << e_max.at(0)       << endl;
-	cout << "Quadratic B-spline:   "   << e_max.at(1)       << endl;
-	cout << "Cubic B-spline:       "   << e_max.at(2)       << endl;
-	cout << "P-spline:             "   << e_max.at(3)       << endl;
-    // cout << "Thin-plate spline:    "   << e_max.at(4)       << endl;
-	cout << "-------------------------------------------"   << endl;
+	Foam::Info << Foam::endl << Foam::endl;
+	Foam::Info << "Evaluating spline errors (using max norm)  "   << Foam::endl;
+	Foam::Info << "-------------------------------------------"   << Foam::endl;
+	Foam::Info << "Linear B-spline:      "   << e_max.at(0)       << Foam::endl;
+	Foam::Info << "Quadratic B-spline:   "   << e_max.at(1)       << Foam::endl;
+	Foam::Info << "Cubic B-spline:       "   << e_max.at(2)       << Foam::endl;
+	Foam::Info << "P-spline:             "   << e_max.at(3)       << Foam::endl;
+    // Foam::Info << "Thin-plate spline:    "   << e_max.at(4)       << Foam::endl;
+	Foam::Info << "-------------------------------------------"   << Foam::endl;
 }
 
 bool compareBSplines(BSpline &bs, const BSpline &bs_orig)
@@ -388,8 +387,8 @@ bool compareBSplines(BSpline &bs, const BSpline &bs_orig)
 			double yb_orig = bs_orig.eval(x);
 			if(std::abs(yb-yb_orig) > 1e-8)
 			{
-				cout << yb << endl;
-				cout << yb_orig << endl;
+				Foam::Info << yb << Foam::endl;
+				Foam::Info << yb_orig << Foam::endl;
 				return false;
 			}
 		}
@@ -443,8 +442,8 @@ bool domainReductionTest(BSpline &bs, const BSpline &bs_orig)
 
 void runRecursiveDomainReductionTest()
 {
-	cout << endl << endl;
-	cout << "Starting recursive domain reduction test..." << endl;
+	Foam::Info << Foam::endl << Foam::endl;
+	Foam::Info << "Starting recursive domain reduction test..." << Foam::endl;
 
     // Create new DataTable to manage samples
 	DataTable samples;
@@ -476,15 +475,15 @@ void runRecursiveDomainReductionTest()
 
 
 	if(domainReductionTest(bspline,bspline))
-		cout << "Test finished successfully!" << endl;
+		Foam::Info << "Test finished successfully!" << Foam::endl;
 	else
-		cout << "Test failed!" << endl;
+		Foam::Info << "Test failed!" << Foam::endl;
 }
 
 void testSplineDerivative()
 {
-	cout << endl << endl;
-	cout << "Testing spline derivative..." << endl;
+	Foam::Info << Foam::endl << Foam::endl;
+	Foam::Info << "Testing spline derivative..." << Foam::endl;
 
     // Create new DataTable to manage samples
 	DataTable samples;
@@ -538,7 +537,7 @@ void testSplineDerivative()
     		DenseMatrix dfdx = spline.evalJacobian(x);
     		if(dfdx.cols() != 2)
     		{
-    			cout << "Test failed - check Jacobian size!" << endl;
+    			Foam::Info << "Test failed - check Jacobian size!" << Foam::endl;
     			return;
     		}
 
@@ -591,16 +590,16 @@ void testSplineDerivative()
     		if(std::abs(dfdx(0) - x0_diff) > tol
     			|| std::abs(dfdx(1) - x1_diff) > tol)
     		{
-    			cout << x0 << ", " << x1 << endl;
-    			cout << dfdx(0) - x0_diff << endl;
-    			cout << dfdx(1) - x1_diff << endl;
-    			cout << "Test failed - check Jacobian!" << endl;
+    			Foam::Info << x0 << ", " << x1 << Foam::endl;
+    			Foam::Info << dfdx(0) - x0_diff << Foam::endl;
+    			Foam::Info << dfdx(1) - x1_diff << Foam::endl;
+    			Foam::Info << "Test failed - check Jacobian!" << Foam::endl;
     			return;
     		}
     	}
     }
 
-    cout << "Test finished successfully!" << endl;
+    Foam::Info << "Test finished successfully!" << Foam::endl;
 }
 
 void run_tests()
@@ -611,15 +610,15 @@ void run_tests()
 
 	runRecursiveDomainReductionTest();
 
-	cout << endl << endl;
-	cout << "Testing load and save functionality:       "   << endl;
-	cout << "-------------------------------------------"   << endl;
-	cout << "test1(): " << (test1() ? "success" : "fail")   << endl;
-	cout << "test2(): " << (test2() ? "success" : "fail")   << endl;
-	cout << "test3(): " << (test3() ? "success" : "fail")   << endl;
-	cout << "test4(): " << (test4() ? "success" : "fail")   << endl;
-	cout << "test5(): " << (test5() ? "success" : "fail")   << endl;
-	cout << "test6(): " << (test6() ? "success" : "fail")   << endl;
+	Foam::Info << Foam::endl << Foam::endl;
+	Foam::Info << "Testing load and save functionality:       "   << Foam::endl;
+	Foam::Info << "-------------------------------------------"   << Foam::endl;
+	Foam::Info << "test1(): " << (test1() ? "success" : "fail")   << Foam::endl;
+	Foam::Info << "test2(): " << (test2() ? "success" : "fail")   << Foam::endl;
+	Foam::Info << "test3(): " << (test3() ? "success" : "fail")   << Foam::endl;
+	Foam::Info << "test4(): " << (test4() ? "success" : "fail")   << Foam::endl;
+	Foam::Info << "test5(): " << (test5() ? "success" : "fail")   << Foam::endl;
+	Foam::Info << "test6(): " << (test6() ? "success" : "fail")   << Foam::endl;
 }
 
 int main(int argc, char **argv)
@@ -630,11 +629,11 @@ int main(int argc, char **argv)
 	}
 	catch(SPLINTER::Exception& e)
 	{
-		cout << "MS Exception - " << e.what() << endl;
+		Foam::Info << "MS Exception - " << e.what() << Foam::endl;
 	}
 	catch(std::exception& e)
 	{
-		cout << "std::exception - " << e.what() << endl;
+		Foam::Info << "std::exception - " << e.what() << Foam::endl;
 	}
 	return 0;
 }


### PR DESCRIPTION
Hello Giovanni, 

I have changed `std::cout` in many codes to `Info` or `Foam::Info`. 
I have run most of the CFD tutorial cases, and the results are correct. 

But I also found other issues in the CFD tutorials when executing. 

1. Bad accuracy: 12simpleSteadyNS, 19UnsteadyNSExplicit
2. No mesh file: 20incrementalPOD
3. No offline or online parameter file: 21unsteadyNSTurb_RBF, 24HyperReduction
4. Fail to run: 26MovingAirfoil

I believe we can discuss those in our next meeting.

With best,
Shenhui